### PR TITLE
Fix issue https://github.com/LycheeOrg/Lychee/issues/120

### DIFF
--- a/scripts/photo.js
+++ b/scripts/photo.js
@@ -671,6 +671,11 @@ photo.setLicense = function(photoID) {
 
 	let oldLicense = photo.json.license;
 
+	const callback = function() {
+		$('select#license').val(photo.json.license);
+		return false;
+	}
+
 	const action = function(data) {
 
 		basicModal.close();
@@ -694,21 +699,28 @@ photo.setLicense = function(photoID) {
 
 	};
 
+	let msg = `
+	<div>
+	  <p>
+		  ` + lychee.locale['PHOTO_NEW_LICENSE'] + `
+		  <select class="select" name="license" id="license">
+			<option value="">${ lychee.locale['PHOTO_LICENSE_NONE'] }</option>
+			<option value="CC0">CC0 - Public Domain</option>
+			<option value="CC-BY">CC Attribution 4.0</option>
+			<option value="CC-BY-ND">CC Attribution-NoDerivatives 4.0</option>
+			<option value="CC-BY-SA">CC Attribution-ShareAlike 4.0</option>
+			<option value="CC-BY-ND">CC Attribution-NonCommercial 4.0</option>
+			<option value="CC-BY-NC-ND">CC Attribution-NonCommercial-NoDerivatives 4.0</option>
+			<option value="CC-BY-SA">CC Attribution-NonCommercial-ShareAlike 4.0</option>
+		</select>
+		<br />
+		<a href="https://creativecommons.org/choose/" target="_blank">${ lychee.locale['PHOTO_LICENSE_HELP'] }</a>
+	  </p>
+	</div>`;
+
 	basicModal.show({
-		body: lychee.html`
-			<p>${ lychee.locale['PHOTO_NEW_LICENSE'] }
-			<select class="select" name="license">
-				<option value="">${ lychee.locale['PHOTO_LICENSE_NONE'] }</option>
-				<option value="CC0">CC0 - Public Domain</option>
-				<option value="CC-BY">CC Attribution 4.0</option>
-				<option value="CC-BY-ND">CC Attribution-NoDerivatives 4.0</option>
-				<option value="CC-BY-SA">CC Attribution-ShareAlike 4.0</option>
-				<option value="CC-BY-ND">CC Attribution-NonCommercial 4.0</option>
-				<option value="CC-BY-NC-ND">CC Attribution-NonCommercial-NoDerivatives 4.0</option>
-				<option value="CC-BY-SA">CC Attribution-NonCommercial-ShareAlike 4.0</option>
-			</select>
-			<br />
-			<a href="https://creativecommons.org/choose/" target="_blank">${ lychee.locale['PHOTO_LICENSE_HELP'] }</a></p>`,
+		body: msg,
+		callback: callback,
 		buttons: {
 			action: {
 				title: lychee.locale['PHOTO_SET_LICENSE'],

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -372,7 +372,6 @@ view.photo = {
 		view.photo.star();
 		view.photo.public();
 		view.photo.photo();
-		view.photo.license();
 
 		photo.json.init = 1
 
@@ -438,7 +437,7 @@ view.photo = {
 	},
 
 	license: function() {
-		if (photo.json.init) sidebar.changeAttr('license', photo.json.license)
+		if (photo.json.init) sidebar.changeAttr('license', photo.json.license);
 	},
 
 	star: function() {


### PR DESCRIPTION
The select box is in a modal, so the `select` element can't be targeted
in `view.photo` because it doesn't exist at load.

`basicModal` supports a callback function. Setting the current license
is done from `photo.json.license` after the modal is visible and called
by the callback function.

I've seen an intermitten flash on the screen when setting a license or
cancelling a license change on `basicModal.` I can't identify a cause
in the debugger or watching the call stack. Can you try to reproduce before
merging?