### PR TITLE
Album-level licenses

### DIFF
--- a/scripts/album.js
+++ b/scripts/album.js
@@ -354,10 +354,8 @@ album.setDescription = function(albumID) {
 
 album.setLicense = function(albumID) {
 
-	let oldLicense = album.json.license;
-
 	const callback = function() {
-		$('select#license').val(album.json.license === '' ? lychee.locale['ALBUM_LICENSE_NONE'] : album.json.license);
+		$('select#license').val(album.json.license === '' ? 'none' : album.json.license);
 		return false;
 	};
 
@@ -366,10 +364,6 @@ album.setLicense = function(albumID) {
 		let license = data.license;
 
 		basicModal.close();
-
-		// if (visible.album()) {
-		//
-		// }
 
 		let params = {
 			albumID,
@@ -381,8 +375,10 @@ album.setLicense = function(albumID) {
 			if(data!==true) {
 				lychee.error(null, params, data);
 			} else {
-				album.json.license = params.license;
-				view.album.license()
+				if (visible.album()) {
+					album.json.license = params.license.license;
+					view.album.license()
+				}
 			}
 		})
 

--- a/scripts/album.js
+++ b/scripts/album.js
@@ -352,6 +352,77 @@ album.setDescription = function(albumID) {
 
 };
 
+album.setLicense = function(albumID) {
+
+	let oldLicense = album.json.license;
+
+	const callback = function() {
+		$('select#license').val(album.json.license === '' ? 'none' : album.json.license);
+		return false;
+	};
+
+	const action = function(data) {
+
+		let license = data.license;
+
+		basicModal.close();
+
+		if (visible.album()) {
+			album.json.license = license;
+			view.album.license()
+		}
+
+		let params = {
+			albumID,
+			license
+		};
+
+		api.post('Album::setLicense', params, function(data) {
+
+			if (data!==true) lychee.error(null, params, data)
+
+		})
+
+	};
+
+	let msg = lychee.html`
+	<div>
+		<p>${ lychee.locale['ALBUM_LICENSE'] }
+		<span class="select" style="width:270px">
+			<select name="license" id="license">
+				<option value="none">${ lychee.locale['ALBUM_LICENSE_NONE'] }</option>
+				<option value="reserved">${ lychee.locale['ALBUM_RESERVED'] }</option>
+				<option value="CC0">CC0 - Public Domain</option>
+				<option value="CC-BY">CC Attribution 4.0</option>
+				<option value="CC-BY-ND">CC Attribution-NoDerivatives 4.0</option>
+				<option value="CC-BY-SA">CC Attribution-ShareAlike 4.0</option>
+				<option value="CC-BY-NC">CC Attribution-NonCommercial 4.0</option>
+				<option value="CC-BY-NC-ND">CC Attribution-NonCommercial-NoDerivatives 4.0</option>
+				<option value="CC-BY-NC-SA">CC Attribution-NonCommercial-ShareAlike 4.0</option>
+			</select>
+		</span>
+		<br />
+		<a href="https://creativecommons.org/choose/" target="_blank">${ lychee.locale['ALBUM_LICENSE_HELP'] }</a>
+		</p>
+	</div>`;
+
+	basicModal.show({
+		body: msg,
+		callback: callback,
+		buttons: {
+			action: {
+				title: lychee.locale['ALBUM_SET_LICENSE'],
+				fn: action
+			},
+			cancel: {
+				title: lychee.locale['CANCEL'],
+				fn: basicModal.close
+			}
+		}
+	})
+
+};
+
 album.setPublic = function(albumID, modal, e) {
 
 	let password = '';

--- a/scripts/album.js
+++ b/scripts/album.js
@@ -357,7 +357,7 @@ album.setLicense = function(albumID) {
 	let oldLicense = album.json.license;
 
 	const callback = function() {
-		$('select#license').val(album.json.license === '' ? 'none' : album.json.license);
+		$('select#license').val(album.json.license === '' ? lychee.locale['ALBUM_LICENSE_NONE'] : album.json.license);
 		return false;
 	};
 
@@ -367,10 +367,9 @@ album.setLicense = function(albumID) {
 
 		basicModal.close();
 
-		if (visible.album()) {
-			album.json.license = license;
-			view.album.license()
-		}
+		// if (visible.album()) {
+		//
+		// }
 
 		let params = {
 			albumID,
@@ -379,8 +378,12 @@ album.setLicense = function(albumID) {
 
 		api.post('Album::setLicense', params, function(data) {
 
-			if (data!==true) lychee.error(null, params, data)
-
+			if(data!==true) {
+				lychee.error(null, params, data);
+			} else {
+				album.json.license = params.license;
+				view.album.license()
+			}
 		})
 
 	};

--- a/scripts/lychee_locale.js
+++ b/scripts/lychee_locale.js
@@ -130,6 +130,12 @@ lychee.locale = {
 		'MOVE_ALBUMS'               : "Move Albums",
 		'NOT_MOVE_ALBUMS'           : "Don't Move",
 		'ROOT'                      : "Root",
+		'ALBUM_REUSE'				: "Reuse",
+		'ALBUM_LICENSE'				: 'License',
+		'ALBUM_SET_LICENSE'			: 'Set License',
+		'ALBUM_LICENSE_HELP'		: 'Need help choosing?',
+		'ALBUM_LICENSE_NONE'		: 'None',
+		'ALBUM_RESERVED'			: 'All Rights Reserved',
 
 		'PHOTO_ABOUT'				: 'About',
 		'PHOTO_BASICS'				: 'Basics',

--- a/scripts/photo.js
+++ b/scripts/photo.js
@@ -668,7 +668,7 @@ photo.share = function(photoID, service) {
 photo.setLicense = function(photoID) {
 
 	const callback = function() {
-		$('select#license').val(photo.json.license === '' ? album.json.license : photo.json.license);
+		$('select#license').val(photo.json.license === '' ? 'none' : photo.json.license); // this is not the place where you do logic (removed the album mention).
 		return false;
 	};
 
@@ -683,8 +683,7 @@ photo.setLicense = function(photoID) {
 		};
 
 		api.post('Photo::setLicense', params, function(data) {
-			console.log(params)
-			console.log(data)
+
 			if (data!==true) {
 				lychee.error(null, params, data)
 			} else {

--- a/scripts/photo.js
+++ b/scripts/photo.js
@@ -668,7 +668,7 @@ photo.share = function(photoID, service) {
 photo.setLicense = function(photoID) {
 
 	const callback = function() {
-		$('select#license').val(photo.json.license === '' ? 'none' : photo.json.license);
+		$('select#license').val(photo.json.license === '' ? album.json.license : photo.json.license);
 		return false;
 	};
 
@@ -683,12 +683,15 @@ photo.setLicense = function(photoID) {
 		};
 
 		api.post('Photo::setLicense', params, function(data) {
-
-			if (data!==true) lychee.error(null, params, data)
-
-			// update the photo JSON and reload the license in the sidebar
-			photo.json.license = params.license;
-			view.photo.license();
+			console.log(params)
+			console.log(data)
+			if (data!==true) {
+				lychee.error(null, params, data)
+			} else {
+				// update the photo JSON and reload the license in the sidebar
+				photo.json.license = params.license;
+				view.photo.license();
+			}
 
 		})
 

--- a/scripts/sidebar.js
+++ b/scripts/sidebar.js
@@ -311,11 +311,9 @@ sidebar.createStructure.album = function(data) {
 
 	// Set license string
 	switch (data.license) {
-		case 'none' 	:   license = lychee.locale['ALBUM_LICENSE_NONE'];
+		case 'none' 	:   license = ''; // consistency
 							break;
 		case 'reserved'	:	license = lychee.locale['ALBUM_RESERVED'];
-							break;
-		case ''			:	license = lychee.default_license;
 							break;
 		default			: 	license = data.license;
 							break;

--- a/scripts/sidebar.js
+++ b/scripts/sidebar.js
@@ -65,7 +65,8 @@ sidebar.bind = function() {
 		.dom('#edit_license')
 		.off(eventName)
 		.on(eventName, function() {
-			photo.setLicense(photo.getID());
+			if (visible.photo())      photo.setLicense(photo.getID());
+			else if (visible.album()) album.setLicense(album.getID())
 		})
 
 	return true
@@ -242,6 +243,7 @@ sidebar.createStructure.album = function(data) {
 	let hidden       = '';
 	let downloadable = '';
 	let password     = '';
+	let license 	 = data.license
 
 	// Enable editable when user logged in
 	if (lychee.publicMode===false && lychee.upload) editable = true;
@@ -323,11 +325,20 @@ sidebar.createStructure.album = function(data) {
 		]
 	};
 
+	structure.license = {
+		title : lychee.locale['ALBUM_REUSE'],
+		type  : sidebar.types.DEFAULT,
+		rows  : [
+			{ title: lychee.locale['ALBUM_LICENSE'], kind: 'license', value: (album.json.license === 'none' ? '' : album.json.license), editable: editable }
+		]
+	}
+
 	// Construct all parts of the structure
 	structure = [
 		structure.basics,
 		structure.album,
-		structure.share
+		structure.share,
+		structure.license
 	];
 
 	return structure

--- a/scripts/sidebar.js
+++ b/scripts/sidebar.js
@@ -129,6 +129,19 @@ sidebar.createStructure.photo = function(data) {
 	// Enable editable when user logged in
 	if (lychee.publicMode===false && lychee.upload) editable = true;
 
+	// Set the license string for a photo
+	switch (data.license) {
+		// if the photo doesn't have a license, apply the album's
+		case 'none' 	:   license = (album.json.license === 'none') ? lychee.locale['ALBUM_LICENSE_NONE'] : album.json.license;
+							break;
+		// Localize All Rights Reserved
+		case 'reserved'	:	license = lychee.locale['PHOTO_RESERVED'];
+							break;
+		// Display anything else that's set
+		default			: 	license = data.license;
+							break;
+	}
+
 	// Set value for public
 	switch (data.public) {
 
@@ -215,7 +228,7 @@ sidebar.createStructure.photo = function(data) {
 		title : lychee.locale['PHOTO_REUSE'],
 		type  : sidebar.types.DEFAULT,
 		rows  : [
-			{ title: lychee.locale['PHOTO_LICENSE'], kind: 'license', value: (photo.json.license === 'none' ? '' : photo.json.license), editable: editable }
+			{ title: lychee.locale['PHOTO_LICENSE'], kind: 'license', value: license, editable: editable }
 		]
 	};
 
@@ -243,7 +256,7 @@ sidebar.createStructure.album = function(data) {
 	let hidden       = '';
 	let downloadable = '';
 	let password     = '';
-	let license 	 = data.license
+	let license 	 = '';
 
 	// Enable editable when user logged in
 	if (lychee.publicMode===false && lychee.upload) editable = true;
@@ -296,6 +309,18 @@ sidebar.createStructure.album = function(data) {
 
 	}
 
+	// Set license string
+	switch (data.license) {
+		case 'none' 	:   license = lychee.locale['ALBUM_LICENSE_NONE'];
+							break;
+		case 'reserved'	:	license = lychee.locale['ALBUM_RESERVED'];
+							break;
+		case ''			:	license = lychee.default_license;
+							break;
+		default			: 	license = data.license;
+							break;
+	}
+
 	structure.basics = {
 		title : lychee.locale['ALBUM_BASICS'],
 		type  : sidebar.types.DEFAULT,
@@ -329,7 +354,7 @@ sidebar.createStructure.album = function(data) {
 		title : lychee.locale['ALBUM_REUSE'],
 		type  : sidebar.types.DEFAULT,
 		rows  : [
-			{ title: lychee.locale['ALBUM_LICENSE'], kind: 'license', value: (album.json.license === 'none' ? '' : album.json.license), editable: editable }
+			{ title: lychee.locale['ALBUM_LICENSE'], kind: 'license', value: license, editable: editable }
 		]
 	}
 

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -294,7 +294,18 @@ view.album = {
 
 	license: function() {
 
-		sidebar.changeAttr('license', album.json.license)
+		switch (album.json.license) {
+			case 'none' 	:   license = lychee.locale['ALBUM_LICENSE_NONE'];
+								break;
+			case 'reserved'	:	license = lychee.locale['ALBUM_RESERVED'];
+								break;
+			case ''			:	license = lychee.default_license;
+								break;
+			default			: 	license = album.json.license;
+								break;
+		}
+
+		sidebar.changeAttr('license', license)
 
 	},
 
@@ -447,7 +458,7 @@ view.photo = {
 
 		// Process key to display correct string
 		if(photo.json.license === 'none') {
-			license = ''; // no license is displayed as '-' (uniformity of the display)
+			license = lychee.locale['PHOTO_LICENSE_NONE']; // no license is displayed as '-' (uniformity of the display)
 		} else if (photo.json.license === 'reserved') {
 			license = lychee.locale['PHOTO_RESERVED'];
 		} else {

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -295,13 +295,12 @@ view.album = {
 	license: function() {
 
 		switch (album.json.license) {
-			case 'none' 	:   license = lychee.locale['ALBUM_LICENSE_NONE'];
+			case 'none' 	:   license = ''; // none is displayed as - thus is empty.
 								break;
 			case 'reserved'	:	license = lychee.locale['ALBUM_RESERVED'];
 								break;
-			case ''			:	license = lychee.default_license;
-								break;
 			default			: 	license = album.json.license;
+			console.log('default');
 								break;
 		}
 
@@ -457,12 +456,13 @@ view.photo = {
 		let license;
 
 		// Process key to display correct string
-		if(photo.json.license === 'none') {
-			license = lychee.locale['PHOTO_LICENSE_NONE']; // no license is displayed as '-' (uniformity of the display)
-		} else if (photo.json.license === 'reserved') {
-			license = lychee.locale['PHOTO_RESERVED'];
-		} else {
-			license = photo.json.license;
+		switch (album.json.license) {
+			case 'none' 	:   license = ''; // none is displayed as - thus is empty (uniformity of the display).
+				break;
+			case 'reserved'	:	license = lychee.locale['PHOTO_RESERVED'];
+				break;
+			default			: 	license = album.json.license;
+				break;
 		}
 
 		// Update the sidebar if the photo is visible

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -292,6 +292,12 @@ view.album = {
 
 	},
 
+	license: function() {
+
+		sidebar.changeAttr('license', album.json.license)
+
+	},
+
 	num: function() {
 
 		sidebar.changeAttr('images', album.json.num)

--- a/styles/_content.scss
+++ b/styles/_content.scss
@@ -88,20 +88,14 @@
 				content: '';
 				position: absolute;
 				display: block;
-				height: 200px;
-				width: 200px;
+				height: 100%;
+				width: 100%;
 				background: url('../play-icon.png') 46% 50%;
 				transition: all 0.3s;
 				will-change: opacity, height;
 			}
 			&:hover::before {
-				content: '';
-				position: absolute;
-				display: block;
-				height: 180px;
 				opacity: 0.75;
-				width: 200px;
-				background: url('../play-icon.png') 46% 50%;
 			}
 		}
 	}


### PR DESCRIPTION
UI updated to display licenses for albums.
- New sidebar section for the visible album showing the current license
- `setLicense()` method added for albums from the sidebar
- Sidebar updates with new license stored in the table on load.