### PR TITLE
Unjustified layout

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,12 +47,12 @@ build.getThumbnailHtml = function(thumb, retinaThumbUrl, type, medium = '', smal
 		return `<span class="thumbimg"><img src='dist/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 	}
 	// we use small if available
-	if (lychee.justified && small !== '')
+	if ((lychee.justified || lychee.unjustified) && small !== '')
 	{
 		return `<span class="thumbimg"><img src='${small}' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 	}
 	// we use medium if small is not available
-	if (lychee.justified && medium !== '')
+	if ((lychee.justified || lychee.unjustified) && medium !== '')
 	{
 		return `<span class="thumbimg"><img src='${medium}' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 	}

--- a/scripts/lychee.js
+++ b/scripts/lychee.js
@@ -21,6 +21,7 @@ lychee = {
 	upload					: false,	// enable possibility to upload (multi-user)
 	lock					: false,	// locked user (multi-user)
 	justified				: true,		// use Flickr Justified Layout Like
+	unjustified				: false,	// use Google Photos Unjustified Layout Like
 	image_overlay			: false,	// display Overlay like in Lightroom
 	image_overlay_default	: false,	// display Overlay like in Lightroom by default
 	image_overlay_type		: 'exif',		// current Overlay display type
@@ -139,6 +140,7 @@ lychee.init = function() {
 			lychee.lang_available		= data.config.lang_available	|| {};
 			lychee.imagick				= (data.config.imagick && data.config.imagick === '1')						|| false;
 			lychee.justified			= (data.config.justified_layout && data.config.justified_layout === '1')	|| false;
+			lychee.unjustified			= (data.config.justified_layout && data.config.justified_layout === '2')	|| false;
 			lychee.image_overlay_default= (data.config.image_overlay && data.config.image_overlay === '1')			|| false;
 			lychee.image_overlay		= lychee.image_overlay_default;
 			lychee.image_overlay_type	= (!data.config.image_overlay_type) ? 'exif' : data.config.image_overlay_type;
@@ -171,6 +173,7 @@ lychee.init = function() {
 			lychee.full_photo	            = (data.config.full_photo == null) || (data.config.full_photo === '1');
 			lychee.checkForUpdates	        = data.config.checkForUpdates || '1';
 			lychee.justified		        = (data.config.justified_layout && data.config.justified_layout === '1') || false;
+			lychee.unjustified		        = (data.config.justified_layout && data.config.justified_layout === '2') || false;
 			lychee.image_overlay	        = (data.config.image_overlay && data.config.image_overlay === '1') || false;
 			lychee.image_overlay_type	    = (!data.config.image_overlay_type) ? 'exif' : data.config.image_overlay_type;
 			lychee.image_overlay_type_default = lychee.image_overlay_type;

--- a/scripts/lychee_locale.js
+++ b/scripts/lychee_locale.js
@@ -278,10 +278,15 @@ lychee.locale = {
 		'CSS_TEXT'					: 'Personalize your CSS:',
 		'CSS_TITLE'				    : 'Change CSS',
 
-		'LAYOUT_TEXT'				: 'Use justified layout:',
+		'LAYOUT_TYPE'				: 'Layout of photos:',
+		'LAYOUT_SQUARES'			: 'Square thumbnails',
+		'LAYOUT_JUSTIFIED'			: 'With aspect, justified',
+		'LAYOUT_UNJUSTIFIED'			: 'With aspect, unjustified',
+		'SET_LAYOUT'				: 'Change layout',
+
 		'IMAGE_OVERLAY_TEXT'		: 'Display image overlay by default:',
 
-		'LAYOUT_TYPE'				: 'Data to use in image overlay:',
+		'OVERLAY_TYPE'				: 'Data to use in image overlay:',
 		'OVERLAY_EXIF'				: 'Photo EXIF data',
 		'OVERLAY_DESCRIPTION'		: 'Photo description',
 		'OVERLAY_DATE'				: 'Photo date taken',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -340,27 +340,18 @@ settings.setDefaultLicense = function(params) {
 		if (data===true) {
 			lychee.default_license = params.license;
 			loadingBar.show('success', lychee.locale['SETTINGS_SUCCESS_LICENSE']);
-		} else lychee.error(ull, params, data)
+		} else lychee.error(null, params, data)
 	})
 };
 
-settings.changeLayout = function () {
+settings.setLayout = function (params) {
 
-	let params = {};
-	if ( $('#JustifiedLayout:checked').length === 1 )
-	{
-		params.justified_layout = '1';
-	}
-	else
-	{
-		params.justified_layout = '0';
-	}
-	api.post('Settings::setLayout', params, function (data) {
+	api.post('Settings::setLayout', params, function(data) {
 		if (data===true) {
+			lychee.justified = (params.layout === "justified");
+			lychee.unjustified = (params.layout === "unjustified");
 			loadingBar.show('success', lychee.locale['SETTINGS_SUCCESS_LAYOUT']);
-			lychee.justified = (params.justified_layout === '1');
 		} else lychee.error(null, params, data)
-
 	})
 };
 

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -204,8 +204,13 @@ view.album = {
 				});
 			}
 
-			if (photosData !== '' && lychee.justified) {
-				photosData = '<div class="justified-layout">' + photosData + '</div>';
+			if (photosData !== '') {
+				if (lychee.justified) {
+					photosData = '<div class="justified-layout">' + photosData + '</div>';
+				}
+				else if (lychee.unjustified) {
+					photosData = '<div class="unjustified-layout">' + photosData + '</div>';
+				}
 			}
 
 			if (albumsData !== '' && photosData !== '')
@@ -226,6 +231,13 @@ view.album = {
 			// Add photos to view
 			lychee.content.html(html);
 			view.album.content.justify();
+			if (lychee.unjustified) {
+				$('.unjustified-layout > div').each(function (i) {
+					$(this).css('width', ((album.json.photos[i].height > 0 ?
+										   album.json.photos[i].width / album.json.photos[i].height : 1) *
+										  parseInt($(this).css('height'), 10)) + 'px');
+				});
+			}
 
 		},
 

--- a/scripts/view.js
+++ b/scripts/view.js
@@ -627,7 +627,8 @@ view.settings = {
 				view.settings.content.setDropboxKey();
 				view.settings.content.setLang();
 				view.settings.content.setDefaultLicense();
-				view.settings.content.setLayoutOverlay();
+				view.settings.content.setLayout();
+				view.settings.content.setOverlay();
 				view.settings.content.setOverlayType();
 				view.settings.content.setCSS();
 				view.settings.content.moreButton();
@@ -813,15 +814,32 @@ view.settings = {
 			settings.bind('#basicModal__action_set_license', '.setDefaultLicense', settings.setDefaultLicense);
 		},
 
-		setLayoutOverlay: function () {
+		setLayout: function() {
 			let msg = `
-			<div class="setLayoutOverlay">
-			<p>${ lychee.locale['LAYOUT_TEXT'] }
-			<label class="switch">
-			  <input id="JustifiedLayout" type="checkbox">
-			  <span class="slider round"></span>
-			</label>
+			<div class="setLayout">
+			<p>${ lychee.locale['LAYOUT_TYPE'] }
+			<span class="select" style="width:270px">
+				<select name="layout" id="layout">
+					<option value="squares">${ lychee.locale['LAYOUT_SQUARES'] }</option>
+					<option value="justified">${ lychee.locale['LAYOUT_JUSTIFIED'] }</option>
+					<option value="unjustified">${ lychee.locale['LAYOUT_UNJUSTIFIED'] }</option>
+				</select>
+			</span>
 			</p>
+			<div class="basicModal__buttons">
+				<a id="basicModal__action_set_layout" class="basicModal__button">${ lychee.locale['SET_LAYOUT'] }</a>
+			</div>
+			</div>
+			`
+			$(".settings_view").append(msg);
+			$('select#layout').val(lychee.justified ? 'justified' :
+								   (lychee.unjustified ? 'unjustified' : 'squares'));
+			settings.bind('#basicModal__action_set_layout', '.setLayout', settings.setLayout);
+		},
+
+		setOverlay: function () {
+			let msg = `
+			<div class="setOverlay">
 			<p>${ lychee.locale['IMAGE_OVERLAY_TEXT'] }
 			<label class="switch">
 			  <input id="ImageOverlay" type="checkbox">
@@ -832,17 +850,15 @@ view.settings = {
 			`;
 
 			$(".settings_view").append(msg);
-			if(lychee.justified) $('#JustifiedLayout').click();
 			if(lychee.image_overlay_default) $('#ImageOverlay').click();
 
-			settings.bind('#JustifiedLayout','.setLayoutOverlay',settings.changeLayout);
-			settings.bind('#ImageOverlay','.setLayoutOverlay',settings.changeImageOverlay);
+			settings.bind('#ImageOverlay','.setOverlay',settings.changeImageOverlay);
 		},
 
 		setOverlayType: function() {
 			let msg =`
 			<div class="setOverlayType">
-			<p>${ lychee.locale['LAYOUT_TYPE'] }
+			<p>${ lychee.locale['OVERLAY_TYPE'] }
 			<span class="select" style="width:270px">
 				<select name="OverlayType" id="ImgOverlayType">
 					<option value="exif">${ lychee.locale['OVERLAY_EXIF'] }</option>

--- a/styles/_justified_layout.scss
+++ b/styles/_justified_layout.scss
@@ -1,5 +1,11 @@
-.justified-layout, .unjustified-layout {
+.justified-layout {
 	margin: 30px 30px 0;
+	width: 100%;
+	position: relative;
+}
+
+.unjustified-layout {
+	margin: 30px 20px -10px 30px;
 	width: 100%;
 	position: relative;
 }

--- a/styles/_justified_layout.scss
+++ b/styles/_justified_layout.scss
@@ -1,4 +1,4 @@
-.justified-layout {
+.justified-layout, .unjustified-layout {
 	margin: 30px 30px 0;
 	width: 100%;
 	position: relative;
@@ -9,14 +9,20 @@
 	margin: 0;
 }
 
-.justified-layout > .photo > .thumbimg > img, .justified-layout > .photo > .thumbimg {
+.unjustified-layout > .photo {
+	float: left;
+	height: 240px;
+	margin: 0 10px 10px 0;
+}
+
+.justified-layout > .photo > .thumbimg > img, .justified-layout > .photo > .thumbimg, .unjustified-layout > .photo > .thumbimg > img, .unjustified-layout > .photo > .thumbimg {
 	width: 100%;
 	height: 100%;
 	border: none;
 	object-fit: cover;
 }
 
-.justified-layout > .photo > .overlay
+.justified-layout > .photo > .overlay, .unjustified-layout > .photo > .overlay
 {
 	width: 100%;
 	bottom: 0;

--- a/styles/_settings.scss
+++ b/styles/_settings.scss
@@ -5,7 +5,7 @@
 	margin-right: auto;
 }
 
-.setLogin, .setSorting, .setDropBox, .setLang, .setLayoutOverlay, .setOverlayType, .setDefaultLicense, .setCSS {
+.setLogin, .setSorting, .setDropBox, .setLang, .setLayout, .setOverlay, .setOverlayType, .setDefaultLicense, .setCSS {
 	font-size: 14px;
 	width: 100%;
 	padding: 5%;


### PR DESCRIPTION
Here's my initial attempt at implementing unjustified layout as described in https://github.com/LycheeOrg/Lychee/issues/199.

In the end I didn't need to use any third-party packages. I just needed to set the dimensions of each `<div photo>` (I originally thought that they could inherit them from the `<img>` tags inside but I guess that's not how it works). With the correct dimensions, the browser takes care of the rest.

I didn't want to hard-code the height of individual images so instead it's set in the CSS so a user should be able to override it. I set it to 240px, which looks good to me (Google Photos has it at 220px by default, I think). Another way to do it would be to tie it to the height of small images, I guess...

I tried to keep the original code as-is as much as possible. In particular, I kept `lychee.justified` unchanged, adding a separate `lychee.unjustified` to control the new layout. If both are `false`, squares are used. If both are `true`, then I don't know what happens, because it's never supposed to be the case :-).

I turned the "Use justified layout" switch into a 3-way selector in the Settings UI. I extended the `justified_layout` field in the database from 0/1 to 0/1/2, 2 being the new unjustified layout (that's in a separate PR against Lychee-Laravel). By the look of it, that's not how it's done for other fields (a text identifier is stored) but I didn't want to deal with modifying the format of settings in the database. Let me know whether that's OK or if I should bite the bullet and keep it consistent with the rest.