### PR TITLE
Frontent part of full HiDPI support

### DIFF
--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -75,6 +75,7 @@ albums._createSmartAlbums = function(data) {
 		sysdate  : data.unsorted.num + ' ' + lychee.locale['NUM_PHOTOS'],
 		unsorted : '1',
 		thumbs   : data.unsorted.thumbs,
+		thumbs2x : data.unsorted.thumbs2x ? data.unsorted.thumbs2x : null,
 		types    : data.unsorted.types
 	};
 
@@ -84,6 +85,7 @@ albums._createSmartAlbums = function(data) {
 		sysdate : data.starred.num + ' ' + lychee.locale['NUM_PHOTOS'],
 		star    : '1',
 		thumbs  : data.starred.thumbs,
+		thumbs2x: data.starred.thumbs2x ? data.starred.thumbs2x : null,
 		types   : data.starred.types
 	};
 
@@ -93,6 +95,7 @@ albums._createSmartAlbums = function(data) {
 		sysdate : data.public.num + ' ' + lychee.locale['NUM_PHOTOS'],
 		public  : '1',
 		thumbs  : data.public.thumbs,
+		thumbs2x: data.public.thumbs2x ? data.public.thumbs2x : null,
 		hidden 	: '1',
 		types   : data.public.types
 	};
@@ -103,6 +106,7 @@ albums._createSmartAlbums = function(data) {
 		sysdate : data.recent.num + ' ' + lychee.locale['NUM_PHOTOS'],
 		recent  : '1',
 		thumbs  : data.recent.thumbs,
+		thumbs2x: data.recent.thumbs2x ? data.recent.thumbs2x : null,
 		types   : data.recent.types
 	}
 

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -4,43 +4,43 @@
 
 build = {};
 
-build.iconic = function(icon, classes = '') {
+build.iconic = function (icon, classes = '') {
 
 	let html = '';
 
-	html += lychee.html`<svg class='iconic ${ classes }'><use xlink:href='#${ icon }' /></svg>`;
+	html += lychee.html`<svg class='iconic ${classes}'><use xlink:href='#${icon}' /></svg>`;
 
 	return html
 
 };
 
-build.divider = function(title) {
+build.divider = function (title) {
 
 	let html = '';
 
-	html += lychee.html`<div class='divider'><h1>${ title }</h1></div>`;
+	html += lychee.html`<div class='divider'><h1>${title}</h1></div>`;
 
 	return html
 
 };
 
-build.editIcon = function(id) {
+build.editIcon = function (id) {
 
 	let html = '';
 
-	html += lychee.html`<div id='${ id }' class='edit'>${ build.iconic('pencil') }</div>`;
+	html += lychee.html`<div id='${id}' class='edit'>${build.iconic('pencil')}</div>`;
 
 	return html
 
 };
 
-build.multiselect = function(top, left) {
+build.multiselect = function (top, left) {
 
-	return lychee.html`<div id='multiselect' style='top: ${ top }px; left: ${ left }px;'></div>`
+	return lychee.html`<div id='multiselect' style='top: ${top}px; left: ${left}px;'></div>`
 
 };
 
-build.getAlbumThumb = function(data, i) {
+build.getAlbumThumb = function (data, i) {
 	let isVideo = data.types[i] && data.types[i].indexOf('video') > -1;
 	let thumb = data.thumbs[i];
 
@@ -48,72 +48,65 @@ build.getAlbumThumb = function(data, i) {
 		return `<span class="thumbimg"><img src='dist/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 	}
 
-	thumb2x = ''
+	thumb2x = '';
 	if (data.thumbs2x) {
 		thumb2x = data.thumbs2x[i]
-	}
-	else { // Fallback code for Lychee v3
-		var { path: thumb2x } = lychee.retinize(data.thumbs[i])
+	} else { // Fallback code for Lychee v3
+		var {path: thumb2x} = lychee.retinize(data.thumbs[i])
 	}
 
-	return `<span class="thumbimg${isVideo ? ' video': ''}"><img src='${thumb}' ${ (thumb2x !== '') ? 'srcset=\'' + thumb2x + ' 2x\'' : '' } alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+	return `<span class="thumbimg${isVideo ? ' video' : ''}"><img src='${thumb}' ${(thumb2x !== '') ? 'srcset=\'' + thumb2x + ' 2x\'' : ''} alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 };
 
-build.album = function(data, disabled = false) {
+build.album = function (data, disabled = false) {
 	let html = '';
 	let date_stamp = data.sysdate;
 	let sortingAlbums = [];
 
 	// In the special case of take date sorting use the take stamps as title
-	if (lychee.sortingAlbums!=='' && data.min_takestamp && data.max_takestamp) {
+	if (lychee.sortingAlbums !== '' && data.min_takestamp && data.max_takestamp) {
 
 		sortingAlbums = lychee.sortingAlbums.replace('ORDER BY ', '').split(' ');
-		if (sortingAlbums[0]==='max_takestamp' || sortingAlbums[0]==='min_takestamp'){
-			if (data.min_takestamp !== '' && data.max_takestamp !== '')
-			{
-				date_stamp = (data.min_takestamp===data.max_takestamp ? data.max_takestamp  : data.min_takestamp + ' - ' + data.max_takestamp)
-			}
-			else if (data.min_takestamp !== '' && sortingAlbums[0]==='min_takestamp')
-			{
+		if (sortingAlbums[0] === 'max_takestamp' || sortingAlbums[0] === 'min_takestamp') {
+			if (data.min_takestamp !== '' && data.max_takestamp !== '') {
+				date_stamp = (data.min_takestamp === data.max_takestamp ? data.max_takestamp : data.min_takestamp + ' - ' + data.max_takestamp)
+			} else if (data.min_takestamp !== '' && sortingAlbums[0] === 'min_takestamp') {
 				date_stamp = data.min_takestamp
-			}
-			else if (data.max_takestamp !== '' && sortingAlbums[0]==='max_takestamp')
-			{
+			} else if (data.max_takestamp !== '' && sortingAlbums[0] === 'max_takestamp') {
 				date_stamp = data.max_takestamp
 			}
 		}
 	}
 
 	html += lychee.html`
-			<div class='album ${ (disabled ? `disabled` : ``) }' data-id='${ data.id }'>
+			<div class='album ${(disabled ? `disabled` : ``)}' data-id='${data.id}'>
 				  ${build.getAlbumThumb(data, 2)}
 				  ${build.getAlbumThumb(data, 1)}
 				  ${build.getAlbumThumb(data, 0)}
 				<div class='overlay'>
-					<h1 title='$${ data.title }'>$${ data.title }</h1>
-					<a>$${ date_stamp }</a>
+					<h1 title='$${data.title}'>$${data.title}</h1>
+					<a>$${date_stamp}</a>
 				</div>
 			`;
 
-	if (lychee.publicMode===false) {
+	if (lychee.publicMode === false) {
 
 		html += lychee.html`
 				<div class='badges'>
-					<a class='badge ${ (data.star==='1'     ? 'badge--star' : '') } icn-star'>${ build.iconic('star') }</a>
-					<a class='badge ${ (data.public==='1'   ? 'badge--visible' : '') } ${ (data.hidden==='1' ? 'badge--not--hidden' : 'badge--hidden') } icn-share'>${ build.iconic('eye') }</a>
-					<a class='badge ${ (data.unsorted==='1' ? 'badge--visible' : '') }'>${ build.iconic('list') }</a>
-					<a class='badge ${ (data.recent==='1'   ? 'badge--visible badge--list' : '') }'>${ build.iconic('clock') }</a>
-					<a class='badge ${ (data.password==='1' ? 'badge--visible' : '') }'>${ build.iconic('lock-locked') }</a>
+					<a class='badge ${(data.star === '1' ? 'badge--star' : '')} icn-star'>${build.iconic('star')}</a>
+					<a class='badge ${(data.public === '1' ? 'badge--visible' : '')} ${(data.hidden === '1' ? 'badge--not--hidden' : 'badge--hidden')} icn-share'>${build.iconic('eye')}</a>
+					<a class='badge ${(data.unsorted === '1' ? 'badge--visible' : '')}'>${build.iconic('list')}</a>
+					<a class='badge ${(data.recent === '1' ? 'badge--visible badge--list' : '')}'>${build.iconic('clock')}</a>
+					<a class='badge ${(data.password === '1' ? 'badge--visible' : '')}'>${build.iconic('lock-locked')}</a>
 				</div>
 				`
 
 	}
 
-	if (data.albums && data.albums.length > 0)
-	{
+	if (data.albums && data.albums.length > 0) {
 		html += lychee.html`
 				<div class='subalbum_badge'>
-					<a class='badge badge--folder'>${ build.iconic('layers') }</a>
+					<a class='badge badge--folder'>${build.iconic('layers')}</a>
 				</div>`;
 	}
 
@@ -123,58 +116,83 @@ build.album = function(data, disabled = false) {
 
 };
 
-build.photo = function(data) {
+build.photo = function (data) {
 
 	let html = '';
+	let thumbnail = '';
+	let thumb2x = '';
 
 	let isVideo = data.type && data.type.indexOf('video') > -1;
 	if (data.thumb === 'uploads/thumb/' && isVideo) {
 		thumbnail = `<span class="thumbimg"><img src='dist/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
-	}
-	else if (lychee.layout === '0') {
-		if (data.thumb2x) {
+	} else if (lychee.layout === '0') {
+
+		if (data.thumb2x) { // Lychee v4
 			thumb2x = data.thumb2x
+		} else { // Lychee v3
+			let {path: thumb2x} = lychee.retinize(data.thumbUrl)
 		}
-		else {
-			var { path: thumb2x } = lychee.retinize(data.thumbUrl)
+
+		if (thumb2x !== '') {
+			thumb2x = `srcset='${thumb2x} 2x'`
 		}
-		thumbnail = `<span class="thumbimg${isVideo ? ' video': ''}"><img src='${data.thumbUrl}' ${ (thumb2x !== '') ? 'srcset=\'' + thumb2x + ' 2x\'' : '' } alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+
+		thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}">`;
+		thumbnail += `<img src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+		thumbnail += `</span>`
 	} else {
+
 		if (data.small !== '') {
-			thumbnail = `<span class="thumbimg"><img src='${data.small}' ${ (data.small2x && data.small2x !== '') ? 'srcset=\'' + data.small + ' ' + parseInt(data.small_dim) + 'w, ' + data.small2x + ' ' + parseInt(data.small2x_dim) + 'w\'' : '' } alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
-		}
-		else if (data.medium !== '') {
-			thumbnail = `<span class="thumbimg"><img src='${data.medium}' ${ (data.medium2x && data.medium2x !== '') ? 'srcset=\'' + data.medium + ' ' + parseInt(data.medium_dim) + 'w, ' + data.medium2x + ' ' + parseInt(data.medium2x_dim) + 'w\'' : '' } alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
-		}
-		else {
+			if (data.small2x && data.small2x !== '') {
+				thumb2x = `srcset='${data.small} ${parseInt(data.small_dim, 10)}w, ${data.small2x} ${parseInt(data.small2x_dim, 10)}w'`
+			}
+			thumbnail = `<span class="thumbimg"><img src='${data.small}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+		} else if (data.medium !== '') {
+			if (data.medium2x && data.medium2x !== '') {
+				thumb2x = `srcset='${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w'`
+			}
+			thumbnail = `<span class="thumbimg"><img src='${data.medium}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+		} else { // safe case if nor medium or small exists
 			if (data.thumb2x) {
 				thumb2x = data.thumb2x
+			} else {
+				let {path: thumb2x} = lychee.retinize(data.thumbUrl)
 			}
-			else {
-				var { path: thumb2x } = lychee.retinize(data.thumbUrl)
+			if (data.thumb2x) { // Lychee v4
+				thumb2x = data.thumb2x
+			} else { // Lychee v3
+				let {path: thumb2x} = lychee.retinize(data.thumbUrl)
 			}
-			thumbnail = `<span class="thumbimg${isVideo ? ' video': ''}"><img src='${data.thumbUrl}' ${ (thumb2x !== '') ? 'srcset=\'' + data.thumbUrl + ' 200w, ' + thumb2x + ' 400w\'' : '' } alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+
+			if (thumb2x !== '') {
+				thumb2x = `srcset='${data.thumbUrl} 200w, ${thumb2x} 400w'`
+			}
+
+			thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}">`;
+			thumbnail += `<img src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+			thumbnail += `</span>`;
 		}
+
 	}
 
 	html += lychee.html`
-			<div class='photo' data-album-id='${ data.album }' data-id='${ data.id }'>
+			<div class='photo' data-album-id='${data.album}' data-id='${data.id}'>
 				${thumbnail}
 				<div class='overlay'>
-					<h1 title='$${ data.title }'>$${ data.title }</h1>
+					<h1 title='$${data.title}'>$${data.title}</h1>
 			`;
 
-	if (data.cameraDate==='1') html += lychee.html`<a><span title='Camera Date'>${ build.iconic('camera-slr') }</span>${ data.takedate }</a>`;
-	else                       html += lychee.html`<a>${ data.sysdate }</a>`;
+	if (data.cameraDate === '1') html += lychee.html`<a><span title='Camera Date'>${build.iconic('camera-slr')}</span>${data.takedate}</a>`;
+	else html += lychee.html`<a>${data.sysdate}</a>`;
 
 	html += `</div>`;
 
-	if (lychee.publicMode===false) {
+	if (lychee.publicMode === false) {
 
 		html += lychee.html`
 				<div class='badges'>
-					<a class='badge ${ (data.star==='1'                                ? 'badge--star' : '') } icn-star'>${ build.iconic('star') }</a>
-					<a class='badge ${ ((data.public==='1' && album.json.public!=='1') ? 'badge--visible' : '') } icn-share'>${ build.iconic('eye') }</a>
+					<a class='badge ${(data.star === '1' ? 'badge--star' : '')} icn-star'>${build.iconic('star')}</a>
+					<a class='badge ${((data.public === '1' && album.json.public !== '1') ? 'badge--visible' : '')} icn-share'>${build.iconic('eye')}</a>
 				</div>
 				`
 
@@ -186,39 +204,35 @@ build.photo = function(data) {
 
 };
 
-build.overlay_image = function(data) {
-	let exifHash  = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
+build.overlay_image = function (data) {
+	let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
 
 	// Get the stored setting for the overlay_image
 	let type = lychee.image_overlay_type;
 	let html = ``;
 
-	if(type && type==='desc' && data.description !== '')
-	{
+	if (type && type === 'desc' && data.description !== '') {
 		html = lychee.html`
 					<div id="image_overlay">
-						<h1>$${ data.title }</h1>
-						<p>$${ data.description }</p>
+						<h1>$${data.title}</h1>
+						<p>$${data.description}</p>
 					</div>
 				`;
-	}
-	else if (type && type==='takedate' && data.takedate !== '')
-	{
+	} else if (type && type === 'takedate' && data.takedate !== '') {
 		html = lychee.html`
 			<div id="image_overlay">
-				<h1>$${ data.title }</h1>
-				<p>${ data.takedate }</p>
+				<h1>$${data.title}</h1>
+				<p>${data.takedate}</p>
 			</div>
 		`
 	}
 	// fall back to exif data if there is no description
-	else if(exifHash !== '')
-	{
+	else if (exifHash !== '') {
 
 		html += lychee.html`
-			<div id="image_overlay"><h1>$${ data.title }</h1>
-			<p>${ data.shutter.replace('s','sec') } at ${ data.aperture.replace('f/','&fnof; / ') }, ${ lychee.locale['PHOTO_ISO'] } ${ data.iso }<br>
-			${ data.focal } ${ (data.lens && data.lens !== '') ? '(' + data.lens+ ')' : ''}</p>
+			<div id="image_overlay"><h1>$${data.title}</h1>
+			<p>${data.shutter.replace('s', 'sec')} at ${data.aperture.replace('f/', '&fnof; / ')}, ${lychee.locale['PHOTO_ISO']} ${data.iso}<br>
+			${data.focal} ${(data.lens && data.lens !== '') ? '(' + data.lens + ')' : ''}</p>
 			</div>
 		`;
 	}
@@ -226,50 +240,58 @@ build.overlay_image = function(data) {
 	return html;
 };
 
-build.imageview = function(data, visibleControls) {
+build.imageview = function (data, visibleControls) {
 
-	let html      = '';
+	let html = '';
 
-	if(data.type.indexOf('video') > -1) {
-		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${ visibleControls===true ? '' : 'full' }' autoplay><source src='${ data.url }'>Your browser does not support the video tag.</video>`
-	}
-	else {
+	if (data.type.indexOf('video') > -1) {
+		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' autoplay><source src='${data.url}'>Your browser does not support the video tag.</video>`
+	} else {
+		let img = '';
+
 		if (data.medium !== '') {
-			html += lychee.html`<img id='image' class='${ visibleControls===true ? '' : 'full' }' src='${ data.medium }' ${ (data.medium2x && data.medium2x !== '') ? 'srcset=\'' + data.medium + ' ' + parseInt(data.medium_dim) + 'w, ' + data.medium2x + ' ' + parseInt(data.medium2x_dim) + 'w\'' : '' } draggable='false'>`
+			let medium = '';
+
+			if (data.medium2x && data.medium2x !== '') {
+				medium = `srcset='${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w'`;
+			}
+			img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.medium}' ` + medium + `  draggable='false' alt='medium'>`
+
+		} else {
+			img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.url}' draggable='false' alt='big'>`
 		}
-		else {
-			html += lychee.html`<img id='image' class='${ visibleControls===true ? '' : 'full' }' src='${ data.url }' draggable='false'>`
-		}
-		if(lychee.image_overlay) html += build.overlay_image(data);
+		html += lychee.html(img);
+
+		if (lychee.image_overlay) html += build.overlay_image(data);
 	}
 
 	html += `
-			<div class='arrow_wrapper arrow_wrapper--previous'><a id='previous'>${ build.iconic('caret-left') }</a></div>
-			<div class='arrow_wrapper arrow_wrapper--next'><a id='next'>${ build.iconic('caret-right') }</a></div>
+			<div class='arrow_wrapper arrow_wrapper--previous'><a id='previous'>${build.iconic('caret-left')}</a></div>
+			<div class='arrow_wrapper arrow_wrapper--next'><a id='next'>${build.iconic('caret-right')}</a></div>
 			`;
 
 	return html
 
 };
 
-build.no_content = function(typ) {
+build.no_content = function (typ) {
 
 	let html = '';
 
-	html += lychee.html`<div class='no_content fadeIn'>${ build.iconic(typ) }`;
+	html += lychee.html`<div class='no_content fadeIn'>${build.iconic(typ)}`;
 
 	switch (typ) {
 		case 'magnifying-glass':
-			html += lychee.html`<p>${ lychee.locale['VIEW_NO_RESULT'] }</p>`;
+			html += lychee.html`<p>${lychee.locale['VIEW_NO_RESULT']}</p>`;
 			break;
 		case 'eye':
-			html += lychee.html`<p>${ lychee.locale['VIEW_NO_PUBLIC_ALBUMS'] }</p>`;
+			html += lychee.html`<p>${lychee.locale['VIEW_NO_PUBLIC_ALBUMS']}</p>`;
 			break;
 		case 'cog':
-			html += lychee.html`<p>${ lychee.locale['VIEW_NO_CONFIGURATION'] }</p>`;
+			html += lychee.html`<p>${lychee.locale['VIEW_NO_CONFIGURATION']}</p>`;
 			break;
 		case 'question-mark':
-			html += lychee.html`<p>${ lychee.locale['VIEW_PHOTO_NOT_FOUND'] }</p>`;
+			html += lychee.html`<p>${lychee.locale['VIEW_PHOTO_NOT_FOUND']}</p>`;
 			break
 	}
 
@@ -279,26 +301,26 @@ build.no_content = function(typ) {
 
 };
 
-build.uploadModal = function(title, files) {
+build.uploadModal = function (title, files) {
 
 	let html = '';
 
 	html += lychee.html`
-			<h1>$${ title }</h1>
+			<h1>$${title}</h1>
 			<div class='rows'>
 			`;
 
 	let i = 0;
 
-	while (i<files.length) {
+	while (i < files.length) {
 
 		let file = files[i];
 
-		if (file.name.length>40) file.name = file.name.substr(0, 17) + '...' + file.name.substr(file.name.length - 20, 20);
+		if (file.name.length > 40) file.name = file.name.substr(0, 17) + '...' + file.name.substr(file.name.length - 20, 20);
 
 		html += lychee.html`
 				<div class='row'>
-					<a class='name'>${ file.name }</a>
+					<a class='name'>${file.name}</a>
 					<a class='status'></a>
 					<p class='notice'></p>
 				</div>
@@ -308,27 +330,27 @@ build.uploadModal = function(title, files) {
 
 	}
 
-	html +=	`</div>`;
+	html += `</div>`;
 
 	return html
 
 };
 
-build.tags = function(tags) {
+build.tags = function (tags) {
 
 	let html = '';
 
-	if (tags!=='') {
+	if (tags !== '') {
 
 		tags = tags.split(',');
 
-		tags.forEach(function(tag, index, array) {
-			html += lychee.html`<a class='tag'>$${ tag }<span data-index='${ index }'>${ build.iconic('x') }</span></a>`
+		tags.forEach(function (tag, index) {
+			html += lychee.html`<a class='tag'>$${tag}<span data-index='${index}'>${build.iconic('x')}</span></a>`
 		})
 
 	} else {
 
-		html = lychee.html`<div class='empty'>${ lychee.locale['NO_TAGS'] }</div>`
+		html = lychee.html`<div class='empty'>${lychee.locale['NO_TAGS']}</div>`
 
 	}
 
@@ -338,9 +360,9 @@ build.tags = function(tags) {
 
 build.user = function (user) {
 	let html = lychee.html`<div class="users_view_line">
-			<p id="UserData${ user.id }">
-			<input name="id" type="hidden" value="${ user.id }" />
-			<input class="text" name="username" type="text" value="$${ user.username }" placeholder="username" />
+			<p id="UserData${user.id}">
+			<input name="id" type="hidden" value="${user.id}" />
+			<input class="text" name="username" type="text" value="$${user.username}" placeholder="username" />
 			<input class="text" name="password" type="text" placeholder="new password" />
 			<span class="choice">
 			<label>
@@ -355,8 +377,8 @@ build.user = function (user) {
 			</label>
 			</span>
 			</p>
-			<a id="UserUpdate${ user.id }"  class="basicModal__button basicModal__button_OK">Save</a>
-			<a id="UserDelete${ user.id }"  class="basicModal__button basicModal__button_DEL">Delete</a>
+			<a id="UserUpdate${user.id}"  class="basicModal__button basicModal__button_OK">Save</a>
+			<a id="UserDelete${user.id}"  class="basicModal__button basicModal__button_DEL">Delete</a>
 		</div>
 		`;
 

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -260,7 +260,7 @@ build.imageview = function (data, visibleControls) {
 		} else {
 			img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.url}' draggable='false' alt='big'>`
 		}
-		html += lychee.html(img);
+		html += lychee.html`${img}`;
 
 		if (lychee.image_overlay) html += build.overlay_image(data);
 	}

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -140,6 +140,7 @@ $(document).ready(function() {
 	// resize
 	.on('resize', function () {
 		if(visible.album()) view.album.content.justify();
+		if(visible.photo()) view.photo.onresize();
 	});
 
 	// Init

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -148,7 +148,22 @@ photo.preloadNext = function(photoID) {
 		let nextPhoto = album.getByID(photoID).nextPhoto;
 		let url       = album.getByID(nextPhoto).url;
 		let medium    = album.getByID(nextPhoto).medium;
-		let href      = (medium!=null && medium!=='' ? medium : url);
+		if (medium != null && medium != '') {
+			href = medium;
+
+			let medium2x  = album.getByID(nextPhoto).medium2x;
+			if (medium2x != null && medium2x != '') {
+				// If the currently displayed image uses the 2x variant,
+				// chances are that so will the next one.
+				imgs=$('img#image');
+				if (imgs.length > 0 && imgs[0].currentSrc != null && imgs[0].currentSrc.includes('@2x.')) {
+					href = medium2x;
+				}
+			}
+		}
+		else {
+			href = url;
+		}
 
 		$('head [data-prefetch]').remove();
 		$('head').append(`<link data-prefetch rel="prefetch" href="${ href }">`)

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -148,21 +148,19 @@ photo.preloadNext = function(photoID) {
 		let nextPhoto = album.getByID(photoID).nextPhoto;
 		let url       = album.getByID(nextPhoto).url;
 		let medium    = album.getByID(nextPhoto).medium;
-		if (medium != null && medium != '') {
+		let href      = url;
+		if (medium != null && medium !== '') {
 			href = medium;
 
-			let medium2x  = album.getByID(nextPhoto).medium2x;
-			if (medium2x != null && medium2x != '') {
+			let medium2x = album.getByID(nextPhoto).medium2x;
+			if (medium2x && medium2x !== '') {
 				// If the currently displayed image uses the 2x variant,
 				// chances are that so will the next one.
-				imgs=$('img#image');
+				let imgs=$('img#image');
 				if (imgs.length > 0 && imgs[0].currentSrc != null && imgs[0].currentSrc.includes('@2x.')) {
 					href = medium2x;
 				}
 			}
-		}
-		else {
-			href = url;
 		}
 
 		$('head [data-prefetch]').remove();
@@ -295,7 +293,7 @@ photo.delete = function(photoIDs) {
 
 		basicModal.close();
 
-		photoIDs.forEach(function(id, index, array) {
+		photoIDs.forEach(function(id) {
 
 			// Change reference for the next and previous photo
 			if (album.getByID(id).nextPhoto!=='' || album.getByID(id).previousPhoto!=='') {
@@ -392,7 +390,7 @@ photo.setTitle = function(photoIDs) {
 			view.photo.title()
 		}
 
-		photoIDs.forEach(function(id, index, array) {
+		photoIDs.forEach(function(id) {
 			album.getByID(id).title = newTitle;
 			view.album.content.title(id)
 		});
@@ -448,7 +446,7 @@ photo.setAlbum = function(photoIDs, albumID) {
 	if (!photoIDs) return false;
 	if (photoIDs instanceof Array===false) photoIDs = [ photoIDs ];
 
-	photoIDs.forEach(function(id, index, array) {
+	photoIDs.forEach(function(id) {
 
 		// Change reference for the next and previous photo
 		if (album.getByID(id).nextPhoto!==''||album.getByID(id).previousPhoto!=='') {
@@ -501,7 +499,7 @@ photo.setStar = function(photoIDs) {
 		view.photo.star()
 	}
 
-	photoIDs.forEach(function(id, index, array) {
+	photoIDs.forEach(function(id) {
 		album.getByID(id).star = (album.getByID(id).star==='0' ? '1' : '0');
 		view.album.content.star(id)
 	});
@@ -627,7 +625,7 @@ photo.editTags = function(photoIDs) {
 	else if (visible.search() && photoIDs.length===1) oldTags = album.getByID(photoIDs).tags;
 	else if (visible.album() && photoIDs.length>1) {
 		let same = true;
-		photoIDs.forEach(function(id, index, array) {
+		photoIDs.forEach(function(id) {
 			same = (album.getByID(id).tags === album.getByID(photoIDs[0]).tags && same === true);
 		});
 		if (same===true) oldTags = album.getByID(photoIDs[0]).tags

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -301,6 +301,11 @@ view.album = {
 					$(this).css('width',layoutGeometry.boxes[i].width);
 					$(this).css('height',layoutGeometry.boxes[i].height);
 					$(this).css('left',layoutGeometry.boxes[i].left);
+
+					let imgs = $(this).find(".thumbimg > img");
+					if (imgs.length > 0 && imgs[0].getAttribute('srcset')) {
+						imgs[0].setAttribute('sizes', layoutGeometry.boxes[i].width + 'px');
+					}
 				});
 			}
 			else if (lychee.layout === '2') {
@@ -311,6 +316,7 @@ view.album = {
 					let height = parseFloat($(this).css('max-height'), 10);
 					let width = height * ratio;
 					let margin = parseFloat($(this).css('margin-right'), 10);
+					let imgs = $(this).find(".thumbimg > img");
 
 					if (width > containerWidth - margin) {
 						width = containerWidth - margin;
@@ -319,6 +325,9 @@ view.album = {
 
 					$(this).css('width', width + 'px');
 					$(this).css('height', height + 'px');
+					if (imgs.length > 0 && imgs[0].getAttribute('srcset')) {
+						imgs[0].setAttribute('sizes', width + 'px');
+					}
 				});
 			}
 		}
@@ -560,6 +569,7 @@ view.photo = {
 	photo: function() {
 
 		lychee.imageview.html(build.imageview(photo.json, visible.header()));
+		view.photo.onresize();
 
 		let $nextArrow     = lychee.imageview.find('a#next');
 		let $previousArrow = lychee.imageview.find('a#previous');
@@ -603,6 +613,27 @@ view.photo = {
 		sidebar.dom('.sidebar__wrapper').html(html);
 		sidebar.bind()
 
+	},
+
+	onresize: function() {
+		if (photo.json.medium === '' || !photo.json.medium2x || photo.json.medium2x === '') return;
+
+		// Calculate the width of the image in the current window and
+		// set 'sizes' to it.
+		let imgWidth = parseInt(photo.json.medium_dim);
+		let imgHeight = photo.json.medium_dim.substr(photo.json.medium_dim.lastIndexOf('x') + 1);
+		let containerWidth = parseFloat($('#imageview').width(), 10);
+		let containerHeight = parseFloat($('#imageview').height(), 10);
+
+		// Image can be no larger than its natural size, but it can be
+		// smaller depending on the size of the window.
+		let width = (imgWidth < containerWidth) ? imgWidth : containerWidth;
+		let height = (width * imgHeight) / imgWidth;
+		if (height > containerHeight) {
+			width = (containerHeight * imgWidth) / imgHeight
+		}
+
+		$('img#image').attr('sizes', width + 'px');
 	}
 
 };


### PR DESCRIPTION
This merge request addresses https://github.com/LycheeOrg/Lychee/issues/198.  See https://github.com/LycheeOrg/Lychee-Laravel/pull/92 for the server part and the overview/motivation of why things are done the way they are.

As implement, support for HiDPI requires extensions to the server API. However, I kept the extensions optional so the new frontend can be used with Lychee v3 without any loss in existing functionality (I only implemented the server changes for the v4).

I thought I would discuss some parts of the patch:

I got rid of `build.getThumbnailHtml()` because extending it to handle HiDPI small/medium would require something like 8 new arguments.  So I replaced it with a much simpler `build.getAlbumThumb()` that's used just for the square thumbnails in albums view, and the rest of the functionality is inlined in `build.photo()` since that was the only user of it.

I added a heuristics to the prefetcher to preload the same variant of the image as the one currently displayed.  The browser chooses which variant to display based on the window size and the variant sizes passed in `srcset` and exports the chosen one via the `currentSrc` DOM property.

When the browser window is resized, the `sizes` tags of the displayed images need to be recalculated to ensure that the browser uses the optimal variant for rendering.  For album view I just extended `view.album.content.justify()`, but for image view I needed to add a new `view.photo.onresize()` method since there wasn't one before.