### PR TITLE
allow download of small & medium files

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -277,9 +277,9 @@ contextMenu.photoMore = function(photoID, e) {
 	
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + lychee.locale['FULL_PHOTO'], visible: lychee.full_photo, fn: () => window.open(photo.getDirectLink()) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD'], visible: showDownload, fn: () => photo.getArchive(photoID) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_MEDIUM'], visible: showMedium, fn: () => photo.getArchiveMedium(photoID) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_SMALL'], visible: showSmall, fn: () => photo.getArchiveSmall(photoID) }
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD'], visible: showDownload, fn: () => photo.getArchive(photoID, 'FULL') },
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_MEDIUM'], visible: showMedium, fn: () => photo.getArchive(photoID, 'MEDIUM') },
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_SMALL'], visible: showSmall, fn: () => photo.getArchive(photoID, 'SMALL') }
 	];
 
 	basicContext.show(items, e.originalEvent)

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -270,10 +270,8 @@ contextMenu.photoMore = function(photoID, e) {
 	// b) Downloadable is 1 and public mode is on
 	let showDownload = lychee.publicMode===false || ((album.json && album.json.downloadable && album.json.downloadable==='1') && lychee.publicMode===true);
 
-	let medium    = album.getByID(photoID).medium;
-	let showMedium = (medium!=null && medium!=='' ? true : false) && showDownload;
-	let small    = album.getByID(photoID).small;
-	let showSmall = (small!=null && small!=='' ? true : false) && showDownload;
+	let showMedium = photo.json.medium && photo.json.medium !== '' && showDownload;
+	let showSmall = photo.json.small && photo.json.small !== '' && showDownload;
 	
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + lychee.locale['FULL_PHOTO'], visible: lychee.full_photo, fn: () => window.open(photo.getDirectLink()) },

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -270,11 +270,16 @@ contextMenu.photoMore = function(photoID, e) {
 	// b) Downloadable is 1 and public mode is on
 	let showDownload = lychee.publicMode===false || ((album.json && album.json.downloadable && album.json.downloadable==='1') && lychee.publicMode===true);
 
+	let medium    = album.getByID(photoID).medium;
+	let showMedium = (medium!=null && medium!=='' ? true : false);
+	let small    = album.getByID(photoID).small;
+	let showSmall = (small!=null && small!=='' ? true : false);
+	
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + lychee.locale['FULL_PHOTO'], visible: lychee.full_photo, fn: () => window.open(photo.getDirectLink()) },
 		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD'], visible: showDownload, fn: () => photo.getArchive(photoID) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_MEDIUM'], visible: showDownload, fn: () => photo.getArchiveMedium(photoID) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_SMALL'], visible: showDownload, fn: () => photo.getArchiveSmall(photoID) }
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_MEDIUM'], visible: showMedium, fn: () => photo.getArchiveMedium(photoID) },
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_SMALL'], visible: showSmall, fn: () => photo.getArchiveSmall(photoID) }
 	];
 
 	basicContext.show(items, e.originalEvent)

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -271,9 +271,9 @@ contextMenu.photoMore = function(photoID, e) {
 	let showDownload = lychee.publicMode===false || ((album.json && album.json.downloadable && album.json.downloadable==='1') && lychee.publicMode===true);
 
 	let medium    = album.getByID(photoID).medium;
-	let showMedium = (medium!=null && medium!=='' ? true : false);
+	let showMedium = (medium!=null && medium!=='' ? true : false) && showDownload;
 	let small    = album.getByID(photoID).small;
-	let showSmall = (small!=null && small!=='' ? true : false);
+	let showSmall = (small!=null && small!=='' ? true : false) && showDownload;
 	
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + lychee.locale['FULL_PHOTO'], visible: lychee.full_photo, fn: () => window.open(photo.getDirectLink()) },

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -272,7 +272,9 @@ contextMenu.photoMore = function(photoID, e) {
 
 	let items = [
 		{ title: build.iconic('fullscreen-enter') + lychee.locale['FULL_PHOTO'], visible: lychee.full_photo, fn: () => window.open(photo.getDirectLink()) },
-		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD'], visible: showDownload, fn: () => photo.getArchive(photoID) }
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD'], visible: showDownload, fn: () => photo.getArchive(photoID) },
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_MEDIUM'], visible: showDownload, fn: () => photo.getArchiveMedium(photoID) },
+		{ title: build.iconic('cloud-download') + lychee.locale['DOWNLOAD_SMALL'], visible: showDownload, fn: () => photo.getArchiveSmall(photoID) }
 	];
 
 	basicContext.show(items, e.originalEvent)

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -73,6 +73,8 @@ lychee.locale = {
 		'DELETE'						: 'Delete',
 		'DELETE_ALL'					: 'Delete All',
 		'DOWNLOAD'						: 'Download',
+		'DOWNLOAD_MEDIUM'				: 'Download medium size',
+		'DOWNLOAD_SMALL'				: 'Download small size',
 		'UPLOAD_PHOTO'					: 'Upload Photo',
 		'IMPORT_LINK'					: 'Import from Link',
 		'IMPORT_DROPBOX'				: 'Import from Dropbox',

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -72,7 +72,7 @@ lychee.locale = {
 		'COPY_ALL_TO'					: 'Copy All to...',
 		'DELETE'						: 'Delete',
 		'DELETE_ALL'					: 'Delete All',
-		'DOWNLOAD'						: 'Download',
+		'DOWNLOAD'						: 'Download original size',
 		'DOWNLOAD_MEDIUM'				: 'Download medium size',
 		'DOWNLOAD_SMALL'				: 'Download small size',
 		'UPLOAD_PHOTO'					: 'Upload Photo',

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -804,7 +804,7 @@ photo.getArchive = function(photoID) {
 photo.getArchiveMedium = function(photoID) {
 
 	let link;
-	let url = `${ api.path }?function=Photo::getArchiveMedium&photoID=${ photoID }`;
+	let url = `${ api.path }?function=Photo::getArchiveMedium&photoID=${ photoID }&kind=MEDIUM`;
 
 	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
 	else                                       link = location.href.replace(location.hash, '') + url;
@@ -819,7 +819,7 @@ photo.getArchiveMedium = function(photoID) {
 photo.getArchiveSmall = function(photoID) {
 
 	let link;
-	let url = `${ api.path }?function=Photo::getArchiveSmall&photoID=${ photoID }`;
+	let url = `${ api.path }?function=Photo::getArchiveSmall&photoID=${ photoID }&kind=SMALL`;
 
 	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
 	else                                       link = location.href.replace(location.hash, '') + url;

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -787,10 +787,10 @@ photo.setLicense = function(photoID) {
 
 };
 
-photo.getArchive = function(photoID) {
+photo.getArchive = function(photoID, kind) {
 
 	let link;
-	let url = `${ api.path }?function=Photo::getArchive&photoID=${ photoID }`;
+	let url = `${ api.path }?function=Photo::getArchive&photoID=${ photoID }&kind=${ kind }`;
 
 	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
 	else                                       link = location.href.replace(location.hash, '') + url;
@@ -800,35 +800,6 @@ photo.getArchive = function(photoID) {
 	location.href = link
 
 };
-
-photo.getArchiveMedium = function(photoID) {
-
-	let link;
-	let url = `${ api.path }?function=Photo::getArchiveMedium&photoID=${ photoID }&kind=MEDIUM`;
-
-	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
-	else                                       link = location.href.replace(location.hash, '') + url;
-
-	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`;
-
-	location.href = link
-
-};
-
-
-photo.getArchiveSmall = function(photoID) {
-
-	let link;
-	let url = `${ api.path }?function=Photo::getArchiveSmall&photoID=${ photoID }&kind=SMALL`;
-
-	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
-	else                                       link = location.href.replace(location.hash, '') + url;
-
-	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`;
-
-	location.href = link
-};
-
 
 photo.getDirectLink = function() {
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -801,6 +801,35 @@ photo.getArchive = function(photoID) {
 
 };
 
+photo.getArchiveMedium = function(photoID) {
+
+	let link;
+	let url = `${ api.path }?function=Photo::getArchiveMedium&photoID=${ photoID }`;
+
+	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
+	else                                       link = location.href.replace(location.hash, '') + url;
+
+	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`;
+
+	location.href = link
+
+};
+
+
+photo.getArchiveSmall = function(photoID) {
+
+	let link;
+	let url = `${ api.path }?function=Photo::getArchiveSmall&photoID=${ photoID }`;
+
+	if (location.href.indexOf('index.html')>0) link = location.href.replace(location.hash, '').replace('index.html', url);
+	else                                       link = location.href.replace(location.hash, '') + url;
+
+	if (lychee.publicMode===true) link += `&password=${ encodeURIComponent(password.value) }`;
+
+	location.href = link
+};
+
+
 photo.getDirectLink = function() {
 
 	let url = '';


### PR DESCRIPTION
See https://github.com/LycheeOrg/Lychee-front/pull/36

Extend frontend to correspond to [LycheeOrg/Lychee#216](https://github.com/LycheeOrg/Lychee/pull/216), implements [LycheeOrg/Lychee#204](https://github.com/LycheeOrg/Lychee/issues/204)

This adds 2 additional entries in the context menu of a photo. The entries only show up if medium and/or small sizes are available.