### PR TITLE
Fix album view on reload in photo view

### DIFF
--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -283,6 +283,13 @@ view.album = {
 		justify: function () {
 			if (!album.json.photos || album.json.photos===false) return;
 			if (lychee.layout === '1') {
+				let containerWidth = parseFloat($('.justified-layout').width(), 10);
+				if (containerWidth == 0) {
+					// Triggered on Reload in photo view.
+					containerWidth = $(window).width() -
+						parseFloat($('.justified-layout').css('margin-left'), 10) -
+						parseFloat($('.justified-layout').css('margin-right'), 10);
+				}
 				let ratio = [];
 				$.each(album.json.photos, function (i) {
 					let l_width = this.width > 0 ? this.width : 200;
@@ -290,7 +297,7 @@ view.album = {
 					ratio[i] = l_width / l_height;
 				});
 				let layoutGeometry = require('justified-layout')(ratio, {
-					containerWidth: $('.justified-layout').width(),
+					containerWidth: containerWidth,
 					containerPadding: 0
 				});
 				if(lychee.admin) console.log(layoutGeometry);
@@ -310,6 +317,12 @@ view.album = {
 			}
 			else if (lychee.layout === '2') {
 				let containerWidth = parseFloat($('.unjustified-layout').width(), 10);
+				if (containerWidth == 0) {
+					// Triggered on Reload in photo view.
+					containerWidth = $(window).width() -
+						parseFloat($('.unjustified-layout').css('margin-left'), 10) -
+						parseFloat($('.unjustified-layout').css('margin-right'), 10);
+				}
 				$('.unjustified-layout > div').each(function (i) {
 					let ratio = album.json.photos[i].height > 0 ?
 								album.json.photos[i].width / album.json.photos[i].height : 1;


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee-Laravel/issues/101.

Basically, on hitting Reload, all the views seem to restart, including the album view "behind" the photo view. Only there is no real album view at that point, so the container width is 0 and all the layout calculations end up being wrong.

Perhaps somebody better versed in JavaScript can come up with a better fix. What I did was add a custom fallback code that does its own calculation of the container width based on the window width.