### PR TITLE
Remove the width restriction from overlay title

### DIFF
--- a/styles/main/_justified_layout.scss
+++ b/styles/main/_justified_layout.scss
@@ -35,3 +35,9 @@
 	bottom: 0;
 	margin: 0 0 0 0;
 }
+
+.justified-layout > .photo > .overlay > h1, .unjustified-layout > .photo > .overlay > h1
+{
+	width: auto;
+	margin-right: 15px;
+}


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee-Laravel/issues/109.
Basically, the justified and unjustified layout inherited `width: 180` from the square layout. This patch resets the width and sets the right margin to be the same as the left one.