### PR TITLE
Don't retinize svg images

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -54,7 +54,10 @@ build.getAlbumThumb = function (data, i) {
 			thumb2x = data.thumbs2x[i]
 		}
 	} else { // Fallback code for Lychee v3
-		var {path: thumb2x} = lychee.retinize(data.thumbs[i])
+		var {path: thumb2x, isPhoto: isPhoto} = lychee.retinize(data.thumbs[i])
+		if (!isPhoto) {
+			thumb2x = ''
+		}
 	}
 
 	return `<span class="thumbimg${isVideo ? ' video' : ''}"><img src='${thumb}' ${(thumb2x !== '') ? 'srcset=\'' + thumb2x + ' 2x\'' : ''} alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`


### PR DESCRIPTION
This is a minor fix to the fallback retinize code for Lychee v3 to ensure that we do not add the `srcset` tag for svg images. It didn't do any harm but it was untidy.