### PR TITLE
Subalbums passwords

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -103,7 +103,7 @@ album.load = function(albumID, refresh = false) {
 		password: ''
 	};
 
-	processData = function(data) {
+	const processData = function (data) {
 
 		if (data === 'Warning: Wrong password!') {
 			// User hit Cancel at the password prompt
@@ -130,7 +130,7 @@ album.load = function(albumID, refresh = false) {
 
 		// Skip delay when refresh is true
 		// Skip delay when opening a blank Lychee
-		if (refresh === true)                                          waitTime = 0;
+		if (refresh === true) waitTime = 0;
 		if (!visible.albums() && !visible.photo() && !visible.album()) waitTime = 0;
 
 		setTimeout(() => {

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -98,64 +98,68 @@ album.getParent = function() {
 
 album.load = function(albumID, refresh = false) {
 
-	password.get(albumID, function() {
+	let params = {
+		albumID,
+		password: ''
+	};
 
-		if (refresh===false) lychee.animate('.content', 'contentZoomOut');
+	processData = function(data) {
 
-		let startTime = new Date().getTime();
+		if (data === 'Warning: Wrong password!') {
+			// User hit Cancel at the password prompt
+			return false
+		}
 
-		let params = {
-			albumID,
-			password: password.value
-		};
+		if (data === 'Warning: Album private!') {
 
-		api.post('Album::get', params, function(data) {
+			if (document.location.hash.replace('#', '').split('/')[1] !== undefined) {
+				// Display photo only
+				lychee.setMode('view')
+			} else {
+				// Album not public
+				lychee.content.show();
+				if (!visible.albums() && !visible.album()) lychee.goto()
+			}
+			return false
+		}
 
-			let waitTime = 0;
+		album.json = data;
 
-			if (data==='Warning: Album private!') {
+		if (refresh === false) lychee.animate('.content', 'contentZoomOut');
+		let waitTime = 300;
 
-				if (document.location.hash.replace('#', '').split('/')[1]!==undefined) {
-					// Display photo only
-					lychee.setMode('view')
-				} else {
-					// Album not public
-					lychee.content.show();
-					lychee.goto()
-				}
-				return false
+		// Skip delay when refresh is true
+		// Skip delay when opening a blank Lychee
+		if (refresh === true)                                          waitTime = 0;
+		if (!visible.albums() && !visible.photo() && !visible.album()) waitTime = 0;
+
+		setTimeout(() => {
+
+			view.album.init();
+
+			if (refresh === false) {
+				lychee.animate(lychee.content, 'contentZoomIn');
+				header.setMode('album')
 			}
 
-			if (data==='Warning: Wrong password!') {
-				album.load(albumID, refresh);
-				return false
-			}
+		}, waitTime)
+	};
 
-			album.json = data;
+	api.post('Album::get', params, function(data) {
 
-			// Calculate delay
-			let durationTime = (new Date().getTime() - startTime);
-			if (durationTime>300) waitTime = 0;
-			else                  waitTime = 300 - durationTime;
+		if (data === 'Warning: Wrong password!') {
+			password.getDialog(albumID, function() {
 
-			// Skip delay when refresh is true
-			// Skip delay when opening a blank Lychee
-			if (refresh===true)                                            waitTime = 0;
-			if (!visible.albums() && !visible.photo() && !visible.album()) waitTime = 0;
+				params.password = password.value;
 
-			setTimeout(() => {
-
-				view.album.init();
-
-				if (refresh===false) {
-					lychee.animate(lychee.content, 'contentZoomIn');
-					header.setMode('album')
-				}
-
-			}, waitTime)
-
-		})
-
+				api.post('Album::get', params, function(data) {
+					processData(data)
+				})
+			})
+		}
+		else {
+			processData(data)
+		}
 	})
 
 };

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -151,6 +151,8 @@ albums.getByID = function(albumID) {
 			json = this;
 			return false; // stop the loop
 		}
+		if (this.albums)
+			$.each(this.albums, func);
 	};
 
 	$.each(albums.json.albums, func);

--- a/scripts/main/password.js
+++ b/scripts/main/password.js
@@ -11,7 +11,6 @@ password = {
 password.get = function(albumID, callback) {
 
 	if (lychee.publicMode===false)                                  callback();
-	else if (album.json && album.json.password==='0')               callback();
 	else if (albums.json && (albums.getByID(albumID).password==='0' || albums.getByID(albumID).passwordProvided)) callback();
 	else if (!albums.json && !album.json) {
 

--- a/scripts/main/password.js
+++ b/scripts/main/password.js
@@ -8,27 +8,6 @@ password = {
 
 };
 
-password.get = function(albumID, callback) {
-
-	if (lychee.publicMode===false)                                  callback();
-	else if (albums.json && (albums.getByID(albumID).password==='0' || albums.getByID(albumID).passwordProvided)) callback();
-	else if (!albums.json && !album.json) {
-
-		// Continue without password
-
-		album.json = { password: true };
-		callback('')
-
-	} else {
-
-		// Request password
-
-		password.getDialog(albumID, callback)
-
-	}
-
-};
-
 password.getDialog = function(albumID, callback) {
 
 	const action = (data) => {
@@ -45,9 +24,6 @@ password.getDialog = function(albumID, callback) {
 			if (data===true) {
 				basicModal.close();
 				password.value = passwd;
-				if (lychee.api_V2 && albums.json) {
-					albums.getByID(albumID).passwordProvided = true;
-				}
 				callback()
 			} else {
 				basicModal.error('password')
@@ -60,7 +36,7 @@ password.getDialog = function(albumID, callback) {
 	const cancel = () => {
 
 		basicModal.close();
-		if (!visible.albums()) lychee.goto()
+		if (!visible.albums() && !visible.album()) lychee.goto()
 
 	};
 


### PR DESCRIPTION
Front-end-side fixes for https://github.com/LycheeOrg/Lychee-Laravel/issues/139

The change to `album.js` makes `albums.getByID()` search recursively through subalbums. It's kind-of amazing how everything else worked fine without it :smiley: 

The change to `password.js` removes a shortcut that appears to be bogus? I'm not sure why the code used to check the password-protection status of the parent album when determining whether to ask for the password of a subalbum. As a result, if the parent album was not password-protected, it would never ask for the password for the subalbum, so a password-protected subalbum could not be opened.