### PR TITLE
Add fullscreen support to album and photo views

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -59,6 +59,8 @@ header.bind = function() {
 		}
 	});
 	header.dom('#button_back')        .on(eventName, function() { lychee.goto(album.getID()) });
+	header.dom('#button_fs_album_enter,#button_fs_enter').on(eventName, lychee.fullscreenEnter);
+	header.dom('#button_fs_album_exit,#button_fs_exit').on(eventName, lychee.fullscreenExit).hide();
 
 	header.dom('.header__search').on('keyup click', function() { search.find($(this).val()) });
 	header.dom('.header__clear').on(eventName, function() {

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -140,7 +140,7 @@ $(document).ready(function() {
 	})
 
 	// Fullscreen
-	.on('fullscreenchange', lychee.fullscreenUpdate);
+	.on('fullscreenchange mozfullscreenchange webkitfullscreenchange msfullscreenchange', lychee.fullscreenUpdate);
 
 	$(window)
 	// resize

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -66,7 +66,10 @@ $(document).ready(function() {
 			else if (visible.albums() && basicModal.visible()===false) { multiselect.selectAll(); return false }
 		})
 		.bind([ 'o' ], function() {
-			if(visible.photo()) { photo.update_overlay_type(); }
+			if(visible.photo()) { photo.update_overlay_type(); return false }
+		})
+		.bind([ 'F' ], function() {
+			if (visible.album() || visible.photo()) { lychee.fullscreenToggle(); return false }
 		});
 
 	Mousetrap.bindGlobal('enter', function() {

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -137,7 +137,10 @@ $(document).ready(function() {
 
 		return false
 
-	});
+	})
+
+	// Fullscreen
+	.on('fullscreenchange', lychee.fullscreenUpdate);
 
 	$(window)
 	// resize

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -576,3 +576,43 @@ lychee.error = function(errorThrown, params = '', data = '') {
 	loadingBar.show('error', errorThrown)
 
 };
+
+lychee.fullscreenEnter = function() {
+	let elem = document.documentElement;
+	if (elem.requestFullscreen) {
+		elem.requestFullscreen();
+	} else if (elem.mozRequestFullScreen) { /* Firefox */
+		elem.mozRequestFullScreen();
+	} else if (elem.webkitRequestFullscreen) { /* Chrome, Safari and Opera */
+		elem.webkitRequestFullscreen();
+	} else if (elem.msRequestFullscreen) { /* IE/Edge */
+		elem.msRequestFullscreen();
+	}
+
+	$('#button_fs_album_enter,#button_fs_enter').hide();
+	$('#button_fs_album_exit,#button_fs_exit').show();
+};
+
+lychee.fullscreenExit = function() {
+	if (document.exitFullscreen) {
+		document.exitFullscreen();
+	} else if (document.mozCancelFullScreen) { /* Firefox */
+		document.mozCancelFullScreen();
+	} else if (document.webkitExitFullscreen) { /* Chrome, Safari and Opera */
+		document.webkitExitFullscreen();
+	} else if (document.msExitFullscreen) { /* IE/Edge */
+		document.msExitFullscreen();
+	}
+
+	$('#button_fs_album_enter,#button_fs_enter').show();
+	$('#button_fs_album_exit,#button_fs_exit').hide();
+};
+
+lychee.fullscreenToggle = function() {
+	if ($('#button_fs_album_enter,#button_fs_enter').is(":visible")) {
+		lychee.fullscreenEnter();
+	}
+	else {
+		lychee.fullscreenExit();
+	}
+};

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -588,9 +588,6 @@ lychee.fullscreenEnter = function() {
 	} else if (elem.msRequestFullscreen) { /* IE/Edge */
 		elem.msRequestFullscreen();
 	}
-
-	$('#button_fs_album_enter,#button_fs_enter').hide();
-	$('#button_fs_album_exit,#button_fs_exit').show();
 };
 
 lychee.fullscreenExit = function() {
@@ -603,16 +600,29 @@ lychee.fullscreenExit = function() {
 	} else if (document.msExitFullscreen) { /* IE/Edge */
 		document.msExitFullscreen();
 	}
-
-	$('#button_fs_album_enter,#button_fs_enter').show();
-	$('#button_fs_album_exit,#button_fs_exit').hide();
 };
 
 lychee.fullscreenToggle = function() {
-	if ($('#button_fs_album_enter,#button_fs_enter').is(":visible")) {
-		lychee.fullscreenEnter();
+	if (lychee.fullscreenStatus()) {
+		lychee.fullscreenExit();
 	}
 	else {
-		lychee.fullscreenExit();
+		lychee.fullscreenEnter();
+	}
+};
+
+lychee.fullscreenStatus = function() {
+	let elem = (document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement || document.msFullscreenElement);
+	return (elem ? true : false);
+}
+
+lychee.fullscreenUpdate = function() {
+	if (lychee.fullscreenStatus()) {
+		$('#button_fs_album_enter,#button_fs_enter').hide();
+		$('#button_fs_album_exit,#button_fs_exit').show();
+	}
+	else {
+		$('#button_fs_album_enter,#button_fs_enter').show();
+		$('#button_fs_album_exit,#button_fs_exit').hide();
 	}
 };

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -42,6 +42,8 @@ lychee.locale = {
 		'DOWNLOAD_ALBUM'	: 'Download Album',
 		'ABOUT_ALBUM'		: 'About Album',
 		'DELETE_ALBUM'		: 'Delete Album',
+		'FULLSCREEN_ENTER'	: 'Enter Fullscreen',
+		'FULLSCREEN_EXIT'	: 'Exit Fullscreen',
 
 		'DELETE_ALBUM_QUESTION'		: 'Delete Album and Photos',
 		'KEEP_ALBUM'					: 'Keep Album',


### PR DESCRIPTION
Finally takes care of my pet project https://github.com/LycheeOrg/Lychee-Laravel/issues/94

There are also corresponding changes to the server(s). Since they are trivial, I implemented them both for v3 and v4.

I added two new buttons to album and photo views (Enter and Exit Fullscreen), only one of which is shown at any one time. I figured it was easier to do it that way than to change the button at run time.

I was wondering whether to also add the buttons to the public (and albums) views, but I thought it might be excessive, especially in the public view case where there aren't any buttons now. Let me know if you think I should add them though.

I also added the 'F' keyboard binding, as requested by @ildyria. While I was there, I fixed the 'o' keyboard binding, which was misbehaving on Firefox.

Overall it seems to work fine, even on mobile browsers (though it would be good if somebody could check on MacOS and iOS; I tested with Firefox and Chrome on Linux and Android)  but one regret I have is that it's independent/unaware of what the user did with respect to fullscreen via F11. As far as I was able to find out, it is impossible to determine that state from JS, apparently deliberately so for "security reasons". :confused:  