### PR TITLE
Cache album passwords in memory

### DIFF
--- a/scripts/main/password.js
+++ b/scripts/main/password.js
@@ -12,7 +12,7 @@ password.get = function(albumID, callback) {
 
 	if (lychee.publicMode===false)                                  callback();
 	else if (album.json && album.json.password==='0')               callback();
-	else if (albums.json && albums.getByID(albumID).password==='0' || albums.getByID(albumID).passwordProvided) callback();
+	else if (albums.json && (albums.getByID(albumID).password==='0' || albums.getByID(albumID).passwordProvided)) callback();
 	else if (!albums.json && !album.json) {
 
 		// Continue without password

--- a/scripts/main/password.js
+++ b/scripts/main/password.js
@@ -12,7 +12,7 @@ password.get = function(albumID, callback) {
 
 	if (lychee.publicMode===false)                                  callback();
 	else if (album.json && album.json.password==='0')               callback();
-	else if (albums.json && albums.getByID(albumID).password==='0') callback();
+	else if (albums.json && albums.getByID(albumID).password==='0' || albums.getByID(albumID).passwordProvided) callback();
 	else if (!albums.json && !album.json) {
 
 		// Continue without password
@@ -46,6 +46,9 @@ password.getDialog = function(albumID, callback) {
 			if (data===true) {
 				basicModal.close();
 				password.value = passwd;
+				if (lychee.api_V2 && albums.json) {
+					albums.getByID(albumID).passwordProvided = true;
+				}
 				callback()
 			} else {
 				basicModal.error('password')


### PR DESCRIPTION
Viewing a password-protected album can be annoying because every time you leave the album and want to re-enter it, you are asked for the password again. This is especially bad if that album has subalbums; the password needs to be reentered when going back from each subalbum to the parent album.

This can be easily prevented by caching the passwords in memory, inside the album object.