### PR TITLE
Don't unbind 'f' in public mode anymore

### DIFF
--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -393,7 +393,6 @@ lychee.setMode = function(mode) {
 			.unbind([ 'u' ])
 			.unbind([ 's' ])
 			.unbind([ 'n' ])
-			.unbind([ 'f' ])
 			.unbind([ 'r' ])
 			.unbind([ 'd' ])
 			.unbind([ 't' ])


### PR DESCRIPTION
@ildyria I thought you wanted it bound to `F`? :smiley:

Anyway, lowercase `f` didn't work in public mode because we explicitly unbind it. This patch fixes it.