### PR TITLE
Hide More button in photo view if menu is empty

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -178,6 +178,10 @@ header.setMode = function(mode) {
 			header.dom().addClass('header--view');
 			header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--album').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--photo').addClass('header__toolbar--visible');
+			// Hide More menu if empty (see contextMenu.photoMore)
+			if (!lychee.full_photo && lychee.publicMode && !(album.json && album.json.downloadable && album.json.downloadable==='1')) {
+				$('#button_more').hide();
+			}
 
 			return true;
 


### PR DESCRIPTION
If `full_photo` is disabled in the settings and the album is not downloadable, there's no point in displaying the More button in photo view in the public mode, since the menu will be empty.