### PR TITLE
Fix rename move delete

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -325,6 +325,9 @@ contextMenu.move = function(IDs, e, callback, kind = 'UNSORTED', display_root = 
 			{
 				exclude.push(album.json.id.toString());
 			}
+			else if (visible.photo()) {
+				exclude.push(photo.json.album.toString());
+			}
 			items = items.concat(contextMenu.buildList(data.albums, exclude.concat(IDs), (a) => callback(IDs, a.id)));
 		}
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -481,9 +481,13 @@ photo.setAlbum = function(photoIDs, albumID) {
 		if (data!==true){
 			lychee.error(null, params, data)
 		}
-		else
-		{
-			if (visible.album()) album.reload();
+		else {
+			if (visible.album() && album.hasSub(albumID)) {
+				// If we moved photos to a subalbum of the currently
+				// displayed album, that may change the subalbum thumbs
+				// being displayed so we need to reload.
+				album.reload();
+			}
 		}
 
 	})

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -293,7 +293,7 @@ photo.delete = function(photoIDs) {
 
 		basicModal.close();
 
-		photoIDs.forEach(function(id) {
+		photoIDs.forEach(function(id, index) {
 
 			// Change reference for the next and previous photo
 			if (album.getByID(id).nextPhoto!=='' || album.getByID(id).previousPhoto!=='') {
@@ -307,7 +307,7 @@ photo.delete = function(photoIDs) {
 			}
 
 			album.deleteByID(id);
-			view.album.content.delete(id)
+			view.album.content.delete(id, (index === photoIDs.length - 1))
 
 		});
 
@@ -446,7 +446,7 @@ photo.setAlbum = function(photoIDs, albumID) {
 	if (!photoIDs) return false;
 	if (photoIDs instanceof Array===false) photoIDs = [ photoIDs ];
 
-	photoIDs.forEach(function(id) {
+	photoIDs.forEach(function(id, index) {
 
 		// Change reference for the next and previous photo
 		if (album.getByID(id).nextPhoto!==''||album.getByID(id).previousPhoto!=='') {
@@ -460,7 +460,7 @@ photo.setAlbum = function(photoIDs, albumID) {
 		}
 
 		album.deleteByID(id);
-		view.album.content.delete(id)
+		view.album.content.delete(id, (index === photoIDs.length - 1))
 
 	});
 

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -257,6 +257,18 @@ view.album = {
 
 		},
 
+		titleSub: function(albumID) {
+
+			let title = album.getSubByID(albumID).title;
+
+			title = lychee.escapeHTML(title);
+
+			$('.album[data-id="' + albumID + '"] .overlay h1')
+				.html(title)
+				.attr('title', title)
+
+		},
+
 		star: function(photoID) {
 
 			let $badge = $('.photo[data-id="' + photoID + '"] .icn-star');
@@ -277,16 +289,30 @@ view.album = {
 
 		delete: function(photoID) {
 
+			if (visible.album() && album.json) {
+				album.json.num--;
+			}
 			$('.photo[data-id="' + photoID + '"]').css('opacity', 0).animate({
 				width: 0,
 				marginLeft: 0
 			}, 300, function () {
 				$(this).remove();
 				// Only when search is not active
-				if (!visible.albums()) {
-					album.json.num--;
+				if (visible.album() && album.json) {
 					view.album.num()
 				}
+			})
+
+		},
+
+		deleteSub: function(albumID) {
+
+			$('.album[data-id="' + albumID + '"]').css('opacity', 0).animate({
+				width: 0,
+				marginLeft: 0
+			}, 300, function () {
+				$(this).remove();
+				if (album.json && album.json.albums.length <= 0) lychee.content.find('.divider').remove()
 			})
 
 		},

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -287,7 +287,7 @@ view.album = {
 
 		},
 
-		delete: function(photoID) {
+		delete: function(photoID, justify = false) {
 
 			if (visible.album() && album.json) {
 				album.json.num--;
@@ -299,7 +299,10 @@ view.album = {
 				$(this).remove();
 				// Only when search is not active
 				if (visible.album() && album.json) {
-					view.album.num()
+					view.album.num();
+					if (justify) {
+						view.album.content.justify()
+					}
 				}
 			})
 


### PR DESCRIPTION
There's a bunch of related fixes here. Most of them are v4-specific, but not all.

The bulk of the changes is in `album.js` and `view.js`. They fix #62 and the related problem when deleting sub-albums. They also fix #68. Basically, support for sub-albums was incomplete so the UI was acting in unexpected and confusing ways (although the right thing was happening on the server side). I effectively added sub-album-specific equivalents of methods that already existed for photos.

One oddity I found in `album.js` was a duplicate definition of `album.getParent()`. I deleted one of them.

The change to `contextMenu.move` is a minor fix to ghost out the parent album of the currently displayed photo in the menu where one can select a destination album for a move operation.

Changes to `photo.js` fix #63; there's also a corresponding change to v`iew.album.content.delete()` that triggers re-justification when the delete is done (should only be needed with the justified layout, BTW -- that's why I didn't add corresponding support for albums, since albums are always displayed as square thumbs). I also optimized the reloading in the browser of the album after a move operation to only take place when potentially necessary (not needed if a photo is moved to an album that is not a descendant of the current one).