### PR TITLE
Add Root to the album title pop-down menu

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -135,8 +135,11 @@ contextMenu.albumTitle = function(albumID, e) {
 
 		let items = [];
 
+		items = items.concat({ title: lychee.locale['ROOT'], fn: () => lychee.goto()});
+
 		if (data.albums && data.albums.length > 1) {
 
+			items = items.concat({});
 			items = items.concat(contextMenu.buildList(data.albums, [ parseInt(albumID, 10) ], (a) => lychee.goto(a.id)));
 
 		}


### PR DESCRIPTION
Implement one of @jprokop1's suggestions from https://github.com/LycheeOrg/Lychee-Laravel/issues/102: add Root album to the list of albums one can switch to.