### PR TITLE
Assorted, v4-specific move/merge fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-rimraf": "^0.2.1",
     "gulp-sass": "^4.0.1",
     "gulp-uglify": "^2.1.1",
-    "jquery": "^3.2.0",
+    "jquery": "^3.4.0",
     "justified-layout": "^2.1.1",
     "lazysizes": "^4.1.7",
     "mousetrap": "^1.6.0",

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -137,14 +137,14 @@ contextMenu.albumTitle = function(albumID, e) {
 
 		items = items.concat({ title: lychee.locale['ROOT'], fn: () => lychee.goto()});
 
-		if (data.albums && data.albums.length > 1) {
+		if (data.albums && data.albums.length > 0) {
 
 			items = items.concat({});
 			items = items.concat(contextMenu.buildList(data.albums, [ parseInt(albumID, 10) ], (a) => lychee.goto(a.id)));
 
 		}
 
-		if (data.shared_albums && data.shared_albums.length >1) {
+		if (data.shared_albums && data.shared_albums.length > 0) {
 
 			items = items.concat({});
 			items = items.concat(contextMenu.buildList(data.shared_albums, [ parseInt(albumID,10) ], (a) => lychee.goto(a.id)));
@@ -311,27 +311,40 @@ contextMenu.move = function(IDs, e, callback, kind = 'UNSORTED', display_root = 
 
 	api.post('Albums::get', {}, function(data) {
 
-		if (data.albums && data.albums.length > 0) {
+		addItems = function(albums) {
 
-			// items = items.concat(contextMenu.buildList(data.albums, [ album.getID() ], (a) => callback(IDs, a.id))); //photo.setAlbum
-
-			// Disable all childs
+			// Disable all children
 			// It's not possible to move us into them
 			let i, s;
 			let exclude = [];
 			for(i = 0; i < IDs.length; i++) {
-				let sub = contextMenu.getSubIDs(data.albums, IDs[i]);
+				let sub = contextMenu.getSubIDs(albums, IDs[i]);
 				for (s = 0 ; s < sub.length ; s++)
 					exclude.push(sub[s])
 			}
-			if (visible.album())
-			{
-				exclude.push(album.json.id.toString());
+			if (visible.album()) {
+				if (callback !== album.merge) {
+					exclude.push(album.json.id.toString());
+				}
 			}
 			else if (visible.photo()) {
 				exclude.push(photo.json.album.toString());
 			}
-			items = items.concat(contextMenu.buildList(data.albums, exclude.concat(IDs), (a) => callback(IDs, a.id)));
+			items = items.concat(contextMenu.buildList(albums, exclude.concat(IDs), (a) => callback(IDs, a.id)));
+		}
+
+		if (data.albums && data.albums.length > 0) {
+
+			// items = items.concat(contextMenu.buildList(data.albums, [ album.getID() ], (a) => callback(IDs, a.id))); //photo.setAlbum
+
+			addItems(data.albums);
+		}
+
+		if (data.shared_albums && data.shared_albums.length > 0 && lychee.admin) {
+
+			items = items.concat({});
+			addItems(data.shared_albums);
+
 		}
 
 		// Show Unsorted when unsorted is not the current album

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -45,6 +45,7 @@ header.bind = function() {
 	header.dom('#button_info')        .on(eventName, sidebar.toggle);
 	header.dom('.button_add')         .on(eventName, contextMenu.add);
 	header.dom('#button_more')        .on(eventName, function(e) { contextMenu.photoMore(photo.getID(), e) });
+	header.dom('#button_move_album')  .on(eventName, function(e) { contextMenu.move([ album.getID() ], e, album.setAlbum, 'ROOT', album.getParent() != '') });
 	header.dom('#button_move')        .on(eventName, function(e) { contextMenu.move([ photo.getID() ], e, photo.setAlbum) });
 	header.dom('.header__hostedwith') .on(eventName, function() { window.open(lychee.website) });
 	header.dom('#button_trash_album') .on(eventName, function() { album.delete([ album.getID() ]) });
@@ -163,12 +164,12 @@ header.setMode = function(mode) {
 			if (lychee.publicMode===true && album.json.downloadable==='0') $('#button_archive').hide();
 
 			if (albumID==='s' || albumID==='f' || albumID==='r') {
-				$('#button_info_album, #button_trash_album, #button_share_album').hide()
+				$('#button_info_album, #button_trash_album, #button_share_album, #button_move_album').hide()
 			} else if (albumID==='0') {
-				$('#button_info_album, #button_share_album').hide();
+				$('#button_info_album, #button_share_album, #button_move_album').hide();
 				$('#button_trash_album').show()
 			} else {
-				$('#button_info_album, #button_trash_album, #button_share_album').show()
+				$('#button_info_album, #button_trash_album, #button_share_album, #button_move_album').show()
 			}
 
 			return true;

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -373,7 +373,7 @@ lychee.setMode = function(mode) {
 	}
 	if (!lychee.upload)
 	{
-		$('#button_trash_album, .button_add').remove();
+		$('#button_trash_album, .button_add, #button_move_album').remove();
 		$('#button_trash, #button_move, #button_star, #button_sharing').remove();
 
 		$('#button_share, #button_share_album')


### PR DESCRIPTION
Fix https://github.com/LycheeOrg/Lychee-Laravel/issues/227: allow merging with the parent album.

Display albums and shared albums in the pull-down navigation bar even if only one is present (in v3 if only one was present then it was guaranteed to be us but in v4 that's not the case).

Allow moving/merging with shared albums if admin (admin should be able to do everything, right?).

Add 'Move Album' button to album view (we had one in photo view so it was conspicuously missing here).