### PR TITLE
Front end fixes for Lychee-Laravel#223

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -49,7 +49,7 @@ build.getAlbumThumb = function (data, i) {
 	}
 
 	thumb2x = '';
-	if (data.thumbs2x) {
+	if (data.hasOwnProperty('thumbs2x')) {
 		if (data.thumbs2x[i]) {
 			thumb2x = data.thumbs2x[i]
 		}
@@ -128,11 +128,11 @@ build.photo = function (data) {
 	var thumb2x = '';
 
 	let isVideo = data.type && data.type.indexOf('video') > -1;
-	if (data.thumb === 'uploads/thumb/' && isVideo) {
+	if (data.thumbUrl === 'uploads/thumb/' && isVideo) {
 		thumbnail = `<span class="thumbimg"><img src='dist/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
 	} else if (lychee.layout === '0') {
 
-		if (data.thumb2x) { // Lychee v4
+		if (data.hasOwnProperty('thumb2x')) { // Lychee v4
 			thumb2x = data.thumb2x
 		} else { // Lychee v3
 			var {path: thumb2x} = lychee.retinize(data.thumbUrl)
@@ -148,7 +148,7 @@ build.photo = function (data) {
 	} else {
 
 		if (data.small !== '') {
-			if (data.small2x && data.small2x !== '') {
+			if (data.hasOwnProperty('small2x') && data.small2x !== '') {
 				thumb2x = `data-srcset='${data.small} ${parseInt(data.small_dim, 10)}w, ${data.small2x} ${parseInt(data.small2x_dim, 10)}w'`
 			}
 
@@ -156,33 +156,35 @@ build.photo = function (data) {
 			thumbnail += `<img class='lazyload' src='dist/placeholder.png' data-src='${data.small}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
 			thumbnail += `</span>`
 		} else if (data.medium !== '') {
-			if (data.medium2x && data.medium2x !== '') {
+			if (data.hasOwnProperty('medium2x') && data.medium2x !== '') {
 				thumb2x = `data-srcset='${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w'`
 			}
 
 			thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}">`;
 			thumbnail += `<img class='lazyload' src='dist/placeholder.png' data-src='${data.medium}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`
 			thumbnail += `</span>`
-		} else {
-
-			thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}">`;
+		} else if (!isVideo) {
+			// Fallback for images with no small or medium.
+			thumbnail = `<span class="thumbimg">`;
 			thumbnail += `<img class='lazyload' src='dist/placeholder.png' data-src='${data.url}' alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
 			thumbnail += `</span>`
+		} else {
+			// Fallback for videos with no small (the case of no thumb is
+			// handled at the top of this function).
 
-		// 	{ // safe case if neither medium nor small exists
-		// 	if (data.thumb2x) { // Lychee v4
-		// 		thumb2x = data.thumb2x
-		// 	} else { // Lychee v3
-		// 		var {path: thumb2x} = lychee.retinize(data.thumbUrl)
-		// 	}
-		//
-		// 	if (thumb2x !== '') {
-		// 		thumb2x = `data-srcset='${data.thumbUrl} 200w, ${thumb2x} 400w'`
-		// 	}
-		//
-		// 	thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}">`;
-		// 	thumbnail += `<img class='lazyload' src='dist/images/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
-		// 	thumbnail += `</span>`;
+			if (data.hasOwnProperty('thumb2x')) { // Lychee v4
+				thumb2x = data.thumb2x
+			} else { // Lychee v3
+				var {path: thumb2x} = lychee.retinize(data.thumbUrl)
+			}
+
+			if (thumb2x !== '') {
+				thumb2x = `data-srcset='${data.thumbUrl} 200w, ${thumb2x} 400w'`
+			}
+
+			thumbnail = `<span class="thumbimg video">`;
+			thumbnail += `<img class='lazyload' src='dist/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+			thumbnail += `</span>`
 		}
 
 	}
@@ -264,7 +266,7 @@ build.imageview = function (data, visibleControls) {
 		if (data.medium !== '') {
 			let medium = '';
 
-			if (data.medium2x && data.medium2x !== '') {
+			if (data.hasOwnProperty('medium2x') && data.medium2x !== '') {
 				medium = `srcset='${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w'`;
 			}
 			img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.medium}' ` + medium + `  draggable='false' alt='medium'>`

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -292,6 +292,9 @@ view.album = {
 					if (album.json.num) {
 						view.album.num();
 					}
+					if (album.json.photos.length <= 0) {
+						lychee.content.find('.divider').remove()
+					}
 					if (justify) {
 						view.album.content.justify()
 					}
@@ -324,9 +327,14 @@ view.album = {
 				}
 				let ratio = [];
 				$.each(album.json.photos, function (i) {
-					let l_width = this.width > 0 ? this.width : 200;
-					let l_height = this.height > 0 ? this.height : 200;
-					ratio[i] = l_width / l_height;
+					ratio[i] = this.height > 0 ? this.width / this.height : 1;
+					if (this.type && this.type.indexOf('video') > -1) {
+						// Video.  If there's no small and medium, we have
+						// to fall back to the square thumb.
+						if (this.small === '' && this.medium === '') {
+							ratio[i] = 1;
+						}
+					}
 				});
 				let layoutGeometry = require('justified-layout')(ratio, {
 					containerWidth: containerWidth,
@@ -357,6 +365,14 @@ view.album = {
 				$('.unjustified-layout > div').each(function (i) {
 					let ratio = album.json.photos[i].height > 0 ?
 						album.json.photos[i].width / album.json.photos[i].height : 1;
+					if (album.json.photos[i].type && album.json.photos[i].type.indexOf('video') > -1) {
+						// Video.  If there's no small and medium, we have
+						// to fall back to the square thumb.
+						if (album.json.photos[i].small === '' && album.json.photos[i].medium === '') {
+							ratio = 1;
+						}
+					}
+
 					let height = parseFloat($(this).css('max-height'), 10);
 					let width = height * ratio;
 					let margin = parseFloat($(this).css('margin-right'), 10);

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -90,7 +90,7 @@
 				display: block;
 				height: 100%;
 				width: 100%;
-				background: url('play-icon.png') 46% 50%;
+				background: url('play-icon.png') no-repeat 46% 50%;
 				transition: all 0.3s;
 				will-change: opacity, height;
 			}


### PR DESCRIPTION
Fix https://github.com/LycheeOrg/Lychee-Laravel/issues/223.

Fix thumbs of low-resolution videos. The detection of `2x` attributes in json objects was not robust. There was a typo `thumb` vs `thumbUrl`. The fallback for video thumbs was missing. The play arrow should only be displayed once.

Also remove the headers above subalbums and photos when the last photo is deleted (we were already doing so when deleting the last subalbum).