### PR TITLE
Add support for tree structure of albums

### DIFF
--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -126,6 +126,9 @@ albums.isShared = function(albumID) {
 			found = true;
 			return false; // stop the loop
 		}
+		if (this.albums) {
+			$.each(this.albums, func)
+		}
 	};
 
 	if (albums.json.shared_albums !== null)
@@ -151,8 +154,9 @@ albums.getByID = function(albumID) {
 			json = this;
 			return false; // stop the loop
 		}
-		if (this.albums)
-			$.each(this.albums, func);
+		if (this.albums) {
+			$.each(this.albums, func)
+		}
 	};
 
 	$.each(albums.json.albums, func);
@@ -167,6 +171,8 @@ albums.getByID = function(albumID) {
 albums.deleteByID = function(albumID) {
 
 	// Function returns the JSON of an album
+	// This function is only ever invoked for top-level albums so it
+	// doesn't need to descend down the albums tree.
 
 	if (albumID==null)       return false;
 	if (!albums.json)        return false;


### PR DESCRIPTION
Always show Merge in album's context menu.

Also exclude current album's parent from move destinations.

Note: server side changes are in https://github.com/LycheeOrg/Lychee-Laravel/pull/232.