### PR TITLE
Prevent attempts to edit shared albums by others

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -911,6 +911,23 @@ album.setAlbum = function (albumIDs, albumID, confirm = true) {
 
 };
 
+album.isUploadable = function() {
+	if (lychee.admin) {
+		return true;
+	}
+	if (lychee.publicMode || !lychee.upload) {
+		return false;
+	}
+
+	// For special cases of no album / smart album / etc. we return true.
+	// It's only for regular non-matching albums that we return false.
+	if (album.json === null || !album.json.owner) {
+		return true;
+	}
+
+	return (album.json.owner === lychee.username);
+}
+
 album.reload = function () {
 
 	let albumID = album.getID();

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -94,7 +94,7 @@ build.album = function (data, disabled = false) {
 				</div>
 			`;
 
-	if (lychee.publicMode === false) {
+	if (album.isUploadable() && !disabled) {
 
 		html += lychee.html`
 				<div class='badges'>
@@ -121,7 +121,7 @@ build.album = function (data, disabled = false) {
 
 };
 
-build.photo = function (data) {
+build.photo = function (data, disabled = false) {
 
 	let html = '';
 	let thumbnail = '';
@@ -190,7 +190,7 @@ build.photo = function (data) {
 	}
 
 	html += lychee.html`
-			<div class='photo' data-album-id='${data.album}' data-id='${data.id}'>
+			<div class='photo ${(disabled ? `disabled` : ``)}' data-album-id='${data.album}' data-id='${data.id}'>
 				${thumbnail}
 				<div class='overlay'>
 					<h1 title='$${data.title}'>$${data.title}</h1>
@@ -201,7 +201,7 @@ build.photo = function (data) {
 
 	html += `</div>`;
 
-	if (lychee.publicMode === false) {
+	if (album.isUploadable()) {
 
 		html += lychee.html`
 				<div class='badges'>

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -103,8 +103,19 @@ contextMenu.buildList = function(lists, exclude, action, parent = 0, layer = 0) 
 			let item = lists[i];
 
 			let thumb = 'img/no_cover.svg';
-			if (item.thumbs && item.thumbs[0]) thumb = item.thumbs[0];
-			else if (item.thumbUrl)             thumb = item.thumbUrl;
+			if (item.thumbs && item.thumbs[0]) {
+				if (item.thumbs[0] === 'uploads/thumb/' && item.types[0] && item.types[0].indexOf('video') > -1) {
+					thumb = 'img/play-icon.png'
+				} else {
+					thumb = item.thumbs[0]
+				}
+			} else if (item.thumbUrl) {
+				if (item.thumbUrl === 'uploads/thumb/' && item.type.indexOf('video') > -1) {
+					thumb = 'img/play-icon.png'
+				} else {
+					thumb = item.thumbUrl
+				}
+			}
 
 			if (item.title==='') item.title = lychee.locale['UNTITLED'];
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -34,32 +34,38 @@ $(document).ready(function() {
 			if (visible.photo()) { $('#imageview a#next').click(); return false }
 		})
 		.bind([ 'u' ], function() {
-			if (!visible.photo()) { $('#upload_files').click(); return false }
+			if (!visible.photo() && album.isUploadable()) { $('#upload_files').click(); return false }
 		})
 		.bind([ 'n' ], function() {
-			if (!visible.photo()) { album.add(); return false }
+			if (!visible.photo() && album.isUploadable()) { album.add(); return false }
 		})
 		.bind([ 's' ], function() {
-			if (visible.photo())       { header.dom('#button_star').click(); return false }
+			if (visible.photo() && album.isUploadable()) { header.dom('#button_star').click(); return false }
 			else if (visible.albums()) { header.dom('.header__search').focus(); return false }
 		})
 		.bind([ 'r' ], function() {
-			if (visible.album())      { album.setTitle(album.getID()); return false }
-			else if (visible.photo()) { photo.setTitle([photo.getID()]); return false }
+			if (album.isUploadable()) {
+				if (visible.album())      { album.setTitle(album.getID()); return false }
+				else if (visible.photo()) { photo.setTitle([photo.getID()]); return false }
+			}
 		})
 		.bind([ 'd' ], function() {
-			if (visible.photo())      { photo.setDescription(photo.getID()); return false }
-			else if (visible.album()) { album.setDescription(album.getID()); return false }
+			if (album.isUploadable()) {
+				if (visible.photo())      { photo.setDescription(photo.getID()); return false }
+				else if (visible.album()) { album.setDescription(album.getID()); return false }
+			}
 		})
 		.bind([ 't' ], function() {
-			if (visible.photo()) { photo.editTags([photo.getID()]); return false }
+			if (visible.photo() && album.isUploadable()) { photo.editTags([photo.getID()]); return false }
 		})
 		.bind([ 'i' ], function() {
 			if (!visible.multiselect()) { sidebar.toggle(); return false }
 		})
 		.bind([ 'command+backspace', 'ctrl+backspace' ], function() {
-			if (visible.photo() && basicModal.visible()===false)      { photo.delete([photo.getID()]); return false }
-			else if (visible.album() && basicModal.visible()===false) { album.delete([album.getID()]); return false }
+			if (album.isUploadable()) {
+				if (visible.photo() && basicModal.visible()===false)      { photo.delete([photo.getID()]); return false }
+				else if (visible.album() && basicModal.visible()===false) { album.delete([album.getID()]); return false }
+			}
 		})
 		.bind([ 'command+a', 'ctrl+a' ], function() {
 			if (visible.album() && basicModal.visible()===false)       { multiselect.selectAll(); return false }
@@ -126,6 +132,10 @@ $(document).ready(function() {
 	// Drag and Drop upload
 	.on('dragover', function() { return false }, false)
 	.on('drop', function(e) {
+
+		if (!album.isUploadable()) {
+			return false;
+		}
 
 		// Close open overlays or views which are correlating with the upload
 		if (visible.photo())       lychee.goto(album.getID());

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -20,6 +20,7 @@ lychee = {
 	admin						: false,	// enable admin mode (multi-user)
 	upload						: false,	// enable possibility to upload (multi-user)
 	lock						: false,	// locked user (multi-user)
+	username					: null,
 	layout						: '1',		// 0: Use default, "square" layout. 1: Use Flickr-like "justified" layout. 2: Use Google-like "unjustified" layout
 	image_overlay				: false,	// display Overlay like in Lightroom
 	image_overlay_default		: false,	// display Overlay like in Lightroom by default
@@ -167,6 +168,7 @@ lychee.init = function() {
 				lychee.upload	= data.admin || data.upload;
 				lychee.admin	= data.admin;
 				lychee.lock		= data.lock;
+				lychee.username = data.username;
 				lychee.setMode('logged_in');
 			}
 

--- a/scripts/main/multiselect.js
+++ b/scripts/main/multiselect.js
@@ -60,7 +60,7 @@ multiselect.toggleItem = function(object, id) {
 multiselect.addItem = function(object, id) {
 
 	if (album.isSmartID(id)) return;
-	if (albums.isShared(id)) return;
+	if (!lychee.admin && albums.isShared(id)) return;
 	if (multiselect.isSelected(id).selected===true) return;
 
 	let isAlbum = object.hasClass('album');
@@ -114,13 +114,10 @@ multiselect.albumClick = function(e, albumObj) {
 
 	let id = albumObj.attr('data-id');
 
-	if (isSelectKeyPressed(e) && lychee.upload)
-	{
-		if (albumObj.hasClass('disabled') && !lychee.admin) return;
+	if (isSelectKeyPressed(e) && album.isUploadable()) {
+		if (albumObj.hasClass('disabled')) return;
 		multiselect.toggleItem(albumObj, id);
-	}
-	else
-	{
+	} else {
 		lychee.goto(id)
 	}
 
@@ -130,13 +127,10 @@ multiselect.photoClick = function(e, photoObj) {
 
 	let id = photoObj.attr('data-id');
 
-	if (isSelectKeyPressed(e) && lychee.upload)
-	{
-		if (photoObj.hasClass('disabled') && !lychee.admin) return;
+	if (isSelectKeyPressed(e) && album.isUploadable()) {
+		if (photoObj.hasClass('disabled')) return;
 		multiselect.toggleItem(photoObj, id);
-	}
-	else
-	{
+	} else {
 		lychee.goto(album.getID() + '/' + id);
 	}
 
@@ -150,7 +144,7 @@ multiselect.albumContextMenu = function(e, albumObj) {
 	let id       = albumObj.attr('data-id');
 	let selected = multiselect.isSelected(id).selected;
 
-	if (albumObj.hasClass('disabled') && !lychee.admin) return;
+	if (albumObj.hasClass('disabled')) return;
 
 	if (selected!==false && multiselect.ids.length > 1) {
 		contextMenu.albumMulti(multiselect.ids, e);
@@ -166,7 +160,7 @@ multiselect.photoContextMenu = function(e, photoObj) {
 	let id       = photoObj.attr('data-id');
 	let selected = multiselect.isSelected(id).selected;
 
-	if (photoObj.hasClass('disabled') && !lychee.admin) return;
+	if (photoObj.hasClass('disabled')) return;
 
 	if (selected!==false && multiselect.ids.length > 1) {
 		contextMenu.photoMulti(multiselect.ids, e);
@@ -198,7 +192,7 @@ multiselect.clearSelection = function() {
 
 multiselect.show = function(e) {
 
-	if (lychee.publicMode)                          return false;
+	if (!album.isUploadable())                      return false;
 	if (!visible.albums() && !visible.album())      return false;
 	if ($('.album:hover, .photo:hover').length!==0) return false;
 	if (visible.search())                           return false;
@@ -344,15 +338,11 @@ multiselect.getSelection = function(e) {
 
 			let id = $(this).attr('data-id');
 
-
-	    if (isSelectKeyPressed(e) && lychee.upload)
-	    {
-		    multiselect.toggleItem($(this), id);
-	    }
-	    else
-	    {
-			  multiselect.addItem($(this), id)
-      }
+			if (isSelectKeyPressed(e)) {
+				multiselect.toggleItem($(this), id);
+			} else {
+				multiselect.addItem($(this), id)
+			}
 
 		}
 
@@ -414,7 +404,7 @@ multiselect.close = function() {
 
 multiselect.selectAll = function() {
 
-	if (lychee.publicMode)                   return false;
+	if (!album.isUploadable())               return false;
 	if (visible.search())                    return false;
 	if (!visible.albums() && !visible.album) return false;
 	if (visible.multiselect())               $('#multiselect').remove();

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -130,14 +130,11 @@ sidebar.createStructure.photo = function(data) {
 
 	if (data==null || data==='') return false;
 
-	let editable  = false;
+	let editable  = album.isUploadable();
 	let exifHash  = data.takedate + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
 	let structure = {};
 	let _public   = '';
 	let isVideo = data.type && data.type.indexOf('video') > -1;
-
-	// Enable editable when user logged in
-	if (lychee.publicMode===false && lychee.upload) editable = true;
 
 	// Set the license string for a photo
 	switch (data.license) {
@@ -205,8 +202,8 @@ sidebar.createStructure.photo = function(data) {
 		}
 	}
 
-	// Only create tags section when user logged in
-	if (lychee.publicMode===false && lychee.upload) {
+	// Only create tags section when the photo is editable
+	if (editable) {
 
 		structure.tags = {
 			title : lychee.locale['PHOTO_TAGS'],
@@ -282,16 +279,13 @@ sidebar.createStructure.album = function(data) {
 
 	if (data==null || data==='') return false;
 
-	let editable     = false;
+	let editable     = album.isUploadable();
 	let structure    = {};
 	let _public      = '';
 	let hidden       = '';
 	let downloadable = '';
 	let password     = '';
 	let license 	 = '';
-
-	// Enable editable when user logged in
-	if (lychee.publicMode===false && lychee.upload) editable = true;
 
 	// Set value for public
 	switch (data.public) {

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -19,12 +19,12 @@ view.albums = {
 
 		if (lychee.landing_page_enable) {
 			if (lychee.title !== 'Lychee v4') {
-				lychee.setTitle(lychee.title, false)
+				lychee.setTitle(lychee.title, true)
 			} else {
-				lychee.setTitle(lychee.locale['ALBUMS'], false)
+				lychee.setTitle(lychee.locale['ALBUMS'], true)
 			}
 		} else {
-			lychee.setTitle(lychee.locale['ALBUMS'], false)
+			lychee.setTitle(lychee.locale['ALBUMS'], true)
 		}
 
 	},
@@ -84,7 +84,7 @@ view.albums = {
 								sharedData += build.divider(alb.owner);
 								current_owner = alb.owner;
 							}
-							sharedData += build.album(alb, true);
+							sharedData += build.album(alb, !lychee.admin);
 						}
 					}
 					// $.each(albums.json.shared_albums, function() {
@@ -164,16 +164,16 @@ view.album = {
 
 			switch (album.getID()) {
 				case 'f':
-					lychee.setTitle(lychee.locale['STARED'], false);
+					lychee.setTitle(lychee.locale['STARED'], true);
 					break;
 				case 's':
-					lychee.setTitle(lychee.locale['PUBLIC'], false);
+					lychee.setTitle(lychee.locale['PUBLIC'], true);
 					break;
 				case 'r':
-					lychee.setTitle(lychee.locale['RECENT'], false);
+					lychee.setTitle(lychee.locale['RECENT'], true);
 					break;
 				case '0':
-					lychee.setTitle(lychee.locale['UNSORTED'], false);
+					lychee.setTitle(lychee.locale['UNSORTED'], true);
 					break;
 				default:
 					if (album.json.init) sidebar.changeAttr('title', album.json.title);
@@ -196,7 +196,7 @@ view.album = {
 			if (album.json.albums && album.json.albums !== false) {
 				$.each(album.json.albums, function () {
 					albums.parse(this);
-					albumsData += build.album(this)
+					albumsData += build.album(this, !album.isUploadable())
 				});
 
 			}
@@ -204,7 +204,7 @@ view.album = {
 
 				// Build photos
 				$.each(album.json.photos, function () {
-					photosData += build.photo(this)
+					photosData += build.photo(this, !album.isUploadable())
 				});
 			}
 


### PR DESCRIPTION
Work in progress. It works for me but needs a little more testing (in particular, I still need to test if I didn't break anything with v3). Some input wouldn't hurt either :smiley:.

The primary functionality is the disabling of editing capabilities in shared albums for regular users. Given that we can trigger edits using header buttons, context menu, and keyboard bindings, it's a lot of code to tweak... Once this is merged, https://github.com/LycheeOrg/Lychee-Laravel/issues/219 can be closed... Also, this part depends on https://github.com/LycheeOrg/Lychee-Laravel/pull/260.

As I was implementing this, I got distracted by something that was on my todo list for a while: enabling the pull-down album/photo list in `publicMode`. Until now it was only available for logged in users, for no good reason as far as I can tell. I also added the list to the albums view (it may not be all that useful there in v3, but with nested albums in v4, it's a different story).

Questions/comments:

I added a new `album.isUploadable()` function which replaces virtually all tests for `lychee.publicMode`. Looking back at how it's used, I'm no longer sure if it should be under `album` or under `lychee` -- as it can safely be invoked when `album.json === null`, and in fact there are many such invocations in the code. So as an exception I welcome bikeshedding input regarding the name :wink:.

The pull-down list used to be available only for editable albums/photos, but now it's available for all. Still, there are a number of instances in the code where it's referred to as "editable". I didn't bother to change those -- should I?