### PR TITLE
Undo albums menu

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -82,7 +82,7 @@ header.bind_back = function () {
 
 	header.dom('.header__title').on(eventName, function () {
 		if (lychee.landing_page_enable && visible.albums()) {
-			window.location.href = '/'
+			window.location.href = '.'
 		}
 		else {
 			return false;

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -19,12 +19,12 @@ view.albums = {
 
 		if (lychee.landing_page_enable) {
 			if (lychee.title !== 'Lychee v4') {
-				lychee.setTitle(lychee.title, true)
+				lychee.setTitle(lychee.title, false)
 			} else {
-				lychee.setTitle(lychee.locale['ALBUMS'], true)
+				lychee.setTitle(lychee.locale['ALBUMS'], false)
 			}
 		} else {
-			lychee.setTitle(lychee.locale['ALBUMS'], true)
+			lychee.setTitle(lychee.locale['ALBUMS'], false)
 		}
 
 	},


### PR DESCRIPTION
Disable the pull-down menu in albums view since it conflicts with the use of the same space as a link to the landing page.

Don't assume that the landing page is at the top-level URL.