### PR TITLE
Fix body scroll locking on iOS for Lightbox

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,6 +94,7 @@ paths.main = {
 		'node_modules/mousetrap/plugins/global-bind/mousetrap-global-bind.min.js',
 		'node_modules/basiccontext/dist/basicContext.min.js',
 		'node_modules/basicmodal/dist/basicModal.min.js',
+		'node_modules/body-scroll-lock/lib/bodyScrollLock.min.js',
 		'node_modules/multiselect-two-sides/dist/js/multiselect.min.js',
 		'node_modules/justified-layout/dist/justified-layout.min.js',
 		'../dist/_main--javascript.js'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-env": "^1.7.0",
     "basiccontext": "^3.5.1",
     "basicmodal": "^3.3.8",
+    "body-scroll-lock": "^2.6.1",
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-babel": "^6.1.2",

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -523,7 +523,9 @@ view.photo = {
 		header.setMode('photo');
 
 		// Make body not scrollable
-		$('body').css('overflow', 'hidden');
+		// use bodyScrollLock package to enable locking on iOS
+		// Simple overflow: hidden not working of iOS Safari
+		bodyScrollLock.disableBodyScroll(lychee.imageview);
 
 		// Fullscreen
 		let timeout = null;
@@ -545,7 +547,7 @@ view.photo = {
 		header.setMode('album');
 
 		// Make body scrollable
-		$('body').css('overflow', 'auto');
+		bodyScrollLock.enableBodyScroll(lychee.imageview);
 
 		// Disable Fullscreen
 		$(document).unbind('mousemove');


### PR DESCRIPTION
Body scroll locking on iOS Safari not working with simple css "overflow: hidden". Vertical swipe movements on iOS cause scrolling of thumbnails in background and visual artifacts for lightbox.

NPM package "body-scroll-lock" provides a simple solution to fix this issue.

See some more details: https://medium.com/jsdownunder/locking-body-scroll-for-all-devices-22def9615177