### PR TITLE
Assorted multiselect fixes

### DIFF
--- a/scripts/main/leftMenu.js
+++ b/scripts/main/leftMenu.js
@@ -41,6 +41,8 @@ leftMenu.open = function () {
 	lychee.footer.addClass('leftMenu__open');
 	header.dom('.header__title').addClass('leftMenu__open');
 	loadingBar.dom().addClass('leftMenu__open');
+
+	multiselect.unbind();
 };
 
 /* Set the width of the side navigation to 0 and the left margin of the page content to 0 */

--- a/scripts/main/multiselect.js
+++ b/scripts/main/multiselect.js
@@ -29,7 +29,7 @@ multiselect.position = {
 
 multiselect.bind = function() {
 
-	$(document).on('mousedown', (e) => { if (e.which===1) multiselect.show(e) });
+	$('.content').on('mousedown', (e) => { if (e.which===1) multiselect.show(e) });
 
 	return true
 
@@ -37,7 +37,7 @@ multiselect.bind = function() {
 
 multiselect.unbind = function() {
 
-	$(document).off('mousedown');
+	$('.content').off('mousedown');
 
 };
 
@@ -256,7 +256,7 @@ multiselect.show = function(e) {
 		multiselect.clearSelection()
 	}
 
-	multiselect.position.top    = e.pageY+1;
+	multiselect.position.top    = e.pageY;
 	multiselect.position.right  = $(document).width() - e.pageX;
 	multiselect.position.bottom = $(window).height() - e.pageY;
 	multiselect.position.left   = e.pageX;

--- a/scripts/main/multiselect.js
+++ b/scripts/main/multiselect.js
@@ -256,7 +256,7 @@ multiselect.show = function(e) {
 		multiselect.clearSelection()
 	}
 
-	multiselect.position.top    = e.pageY;
+	multiselect.position.top    = e.pageY+1;
 	multiselect.position.right  = $(document).width() - e.pageX;
 	multiselect.position.bottom = $(window).height() - e.pageY;
 	multiselect.position.left   = e.pageX;

--- a/scripts/main/multiselect.js
+++ b/scripts/main/multiselect.js
@@ -13,7 +13,8 @@ multiselect = {
 
 	ids            : [],
 	albumsSelected : 0,
-	photosSelected : 0
+	photosSelected : 0,
+	lastClicked    : null
 
 };
 
@@ -89,6 +90,8 @@ multiselect.addItem = function(object, id) {
 		multiselect.photosSelected++
 	}
 
+	multiselect.lastClicked = object
+
 };
 
 
@@ -112,6 +115,8 @@ multiselect.removeItem = function(object, id) {
 		multiselect.photosSelected--
 	}
 
+	multiselect.lastClicked = object
+
 };
 
 
@@ -125,26 +130,19 @@ multiselect.albumClick = function(e, albumObj) {
 
 		if (isSelectKeyPressed(e)) {
 			multiselect.toggleItem(albumObj, id)
-		} else if (!multiselect.isSelected(id).selected) {
-			// Click with Shift on an element that was not selected.
-			// Select all elements between the current element and the nearest selected one.
+		} else {
 			if (multiselect.albumsSelected > 0) {
-				// Find the nearest preceding album that's selected.
-				let selected = albumObj.prevAll('.selected').last();
+				// Click with Shift. Select all elements between the current
+				// element and the last clicked-on one.
 
-				if (selected.length > 0) {
-					albumObj.prevUntil(selected, '.album').each(function() {
+				if (albumObj.prevAll('.album').toArray().includes(multiselect.lastClicked[0])) {
+					albumObj.prevUntil(multiselect.lastClicked, '.album').each(function() {
 						multiselect.addItem($(this), $(this).attr('data-id'))
 					})
-				} else {
-					// No preceding selected album?  Check after the current one.
-					selected = albumObj.nextAll('.selected').first();
-
-					if (selected.length > 0) {
-						albumObj.nextUntil(selected, '.album').each(function() {
-							multiselect.addItem($(this), $(this).attr('data-id'))
-						})
-					}
+				} else if (albumObj.nextAll('.album').toArray().includes(multiselect.lastClicked[0])) {
+					albumObj.nextUntil(multiselect.lastClicked, '.album').each(function() {
+						multiselect.addItem($(this), $(this).attr('data-id'))
+					})
 				}
 			}
 
@@ -165,26 +163,19 @@ multiselect.photoClick = function(e, photoObj) {
 
 		if (isSelectKeyPressed(e)) {
 			multiselect.toggleItem(photoObj, id)
-		} else if (!multiselect.isSelected(id).selected) {
-			// Click with Shift on an element that was not selected.
-			// Select all elements between the current element and the nearest selected one.
+		} else {
 			if (multiselect.photosSelected > 0) {
-				// Find the nearest preceding album that's selected.
-				let selected = photoObj.prevAll('.selected').last();
+				// Click with Shift. Select all elements between the current
+				// element and the last clicked-on one.
 
-				if (selected.length > 0) {
-					photoObj.prevUntil(selected, '.photo').each(function() {
+				if (photoObj.prevAll('.photo').toArray().includes(multiselect.lastClicked[0])) {
+					photoObj.prevUntil(multiselect.lastClicked, '.photo').each(function() {
 						multiselect.addItem($(this), $(this).attr('data-id'))
 					})
-				} else {
-					// No preceding selected album?  Check after the current one.
-					selected = photoObj.nextAll('.selected').first();
-
-					if (selected.length > 0) {
-						photoObj.nextUntil(selected, '.photo').each(function() {
-							multiselect.addItem($(this), $(this).attr('data-id'))
-						})
-					}
+				} else if (photoObj.nextAll('.photo').toArray().includes(multiselect.lastClicked[0])) {
+					photoObj.nextUntil(multiselect.lastClicked, '.photo').each(function() {
+						multiselect.addItem($(this), $(this).attr('data-id'))
+					})
 				}
 			}
 
@@ -246,7 +237,8 @@ multiselect.clearSelection = function() {
 	multiselect.deselect('.photo.active, .album.active');
 	multiselect.ids = [];
 	multiselect.albumsSelected = 0;
-	multiselect.photosSelected = 0
+	multiselect.photosSelected = 0;
+	multiselect.lastClicked = null
 
 };
 
@@ -298,7 +290,7 @@ multiselect.resize = function(e) {
 
 		newCSS.top    = multiselect.position.top;
 		newCSS.bottom = 'inherit';
-		newCSS.height = Math.min(e.pageY, $(document).height() - 2) - multiselect.position.top
+		newCSS.height = Math.min(e.pageY, $(document).height() - 3) - multiselect.position.top
 
 	} else {
 
@@ -312,7 +304,7 @@ multiselect.resize = function(e) {
 
 		newCSS.right = 'inherit';
 		newCSS.left  = multiselect.position.left;
-		newCSS.width = Math.min(e.pageX, $(document).width() - 2) - multiselect.position.left
+		newCSS.width = Math.min(e.pageX, $(document).width() - 3) - multiselect.position.left
 
 	} else {
 

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -746,7 +746,6 @@ view.settings = {
 	},
 
 	clearContent: function () {
-		lychee.content.unbind('mousedown');
 		lychee.content.html('<div class="settings_view"></div>');
 	},
 
@@ -1087,7 +1086,6 @@ view.full_settings = {
 	},
 
 	clearContent: function () {
-		lychee.content.unbind('mousedown');
 		lychee.content.html('<div class="settings_view"></div>');
 	},
 
@@ -1169,7 +1167,6 @@ view.users = {
 	},
 
 	clearContent: function () {
-		lychee.content.unbind('mousedown');
 		lychee.content.html('<div class="users_view"></div>');
 	},
 
@@ -1257,7 +1254,6 @@ view.sharing = {
 	},
 
 	clearContent: function () {
-		lychee.content.unbind('mousedown');
 		lychee.content.html('<div class="sharing_view"></div>');
 	},
 
@@ -1381,7 +1377,6 @@ view.logs = {
 	},
 
 	clearContent: function () {
-		lychee.content.unbind('mousedown');
 		let html = '';
 		if (lychee.api_V2) {
 			html += lychee.html`<div class="clear_logs_update"><a id="Clean_Noise" class="basicModal__button">${lychee.locale['CLEAN_LOGS']}</a></div>`;
@@ -1424,7 +1419,6 @@ view.diagnostics = {
 	},
 
 	clearContent: function (update) {
-		lychee.content.unbind('mousedown');
 		let html = '';
 		if (update === 1) {
 			html += lychee.html`<div class="clear_logs_update"><a id="Update_Lychee" class="basicModal__button">${lychee.locale['UPDATE_AVAILABLE']}</a></div>`;

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -546,6 +546,9 @@ view.photo = {
 			timeout = setTimeout(header.hide, 2500)
 		});
 
+		// we also put this timeout to enable it by default when you directly click on a picture.
+		setTimeout(header.hide, 2500);
+
 		lychee.animate(lychee.imageview, 'fadeIn')
 
 	},

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -2,9 +2,10 @@
 
 	display: flex;
 	flex-wrap: wrap;
+	align-content: flex-start;
 	padding: 50px 30px 33px 0;
 	width: calc(100% - 30px);
-	min-height: unset;
+	min-height: calc(100vh - 83px - 36px);
 	transition: margin-left .5s;
 	-webkit-overflow-scrolling: touch;
 	max-width: calc(100vw - 10px);

--- a/styles/main/_multiselect.scss
+++ b/styles/main/_multiselect.scss
@@ -3,5 +3,5 @@
 	background-color: rgba(0, 94, 204, .3);
 	border: 1px solid rgba(0, 94, 204, 1);
 	border-radius: 3px;
-	z-index: 3;
+	z-index: 5;
 }

--- a/styles/main/_sidebar.scss
+++ b/styles/main/_sidebar.scss
@@ -9,6 +9,7 @@
 	border-left: 1px solid black(.2);
 	transform: translateX(0);
 	transition: transform .3s $timing;
+	z-index: 4;
 
 	&.active {
 		transform: translateX(-360px);


### PR DESCRIPTION
Fixes #75, #84, and more.

Rational support for "Select all" in albums with photos and subalbums
(do not generate an error message).

Add support for Shift key to select a range of albums or photos.

Intuitive clearing of selection with a single click.

multiselect.removeItem() didn't work correctly for non-first items.

Selection couldn't start much below the last picture in albums with just
a few pictures (i.e., those that had whitespace there).

Cleaned up calculations of selection and overlap.

New multiselect.unbind() function to match the existing
multiselect.bind().