### PR TITLE
Assorted fixes

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -225,8 +225,6 @@ header.setMode = function(mode) {
 				|| (photo.json && photo.json.url && photo.json.url === '') ) {
 				$('#button_more').hide();
 			}
-			console.log(album.json);
-			console.log(photo.json);
 
 			return true;
 

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -348,8 +348,8 @@ lychee.load = function() {
 
 lychee.getUpdate = function() {
 
-	console.log(lychee.update_available);
-	console.log(lychee.update_json);
+	// console.log(lychee.update_available);
+	// console.log(lychee.update_json);
 
 	if(lychee.update_json !== 0)
 	{

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -121,7 +121,7 @@ photo.update_overlay_type = function() {
 		}
 		else
 		{
-			console.log('no other data found, displaying ' + types[j]);
+			// console.log('no other data found, displaying ' + types[j]);
 		}
 	}
 };

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -350,7 +350,7 @@ view.album = {
 					containerWidth: containerWidth,
 					containerPadding: 0
 				});
-				if (lychee.admin) console.log(layoutGeometry);
+				// if (lychee.admin) console.log(layoutGeometry);
 				$('.justified-layout').css('height', layoutGeometry.containerHeight + 'px')
 					.css('height', layoutGeometry.containerHeight + 'px');
 				$('.justified-layout > div').each(function (i) {
@@ -434,7 +434,7 @@ view.album = {
 				break;
 			default            :
 				license = album.json.license;
-				console.log('default');
+				// console.log('default');
 				break;
 		}
 

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -166,4 +166,11 @@
 		}
 	}
 
+	// We must not allow the wide next/prev arrow wrappers to cover the
+	// on-screen buttons in videos.  This is imperfect as now the video
+	// covers part of the background image.
+	video {
+		z-index: 1;
+	}
+
 }


### PR DESCRIPTION
This branch used to contain more changes but I pulled some of them into `download-improvements`.

What remains is the commenting out of the debug output and preventing the next/prev arrow wrappers from overlapping the video playback. The latter is necessary because the video playback widget typically contains buttons such as start/stop, and they end up being impossible to click on because the arrow wrappers cover them. It's very confusing when one tries to click on Pause and instead a previous image is loaded...

As I wrote in the comment, the result is imperfect (now the video playback tends to cover part of the background image behind the prev/next arrows) but I can't think of an easy way to make it better.