### PR TITLE
Nextprev improvements

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -257,11 +257,23 @@ build.overlay_image = function (data) {
 build.imageview = function (data, visibleControls) {
 
 	let html = '';
+	let thumb = '';
 
 	if (data.type.indexOf('video') > -1) {
 		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' autoplay><source src='${data.url}'>Your browser does not support the video tag.</video>`
 	} else {
 		let img = '';
+
+		// See if we have the thumbnail loaded...
+		$('.photo').each(function () {
+			if ($(this).attr('data-id') && $(this).attr('data-id') == data.id) {
+				let thumbimg = $(this).find('img');
+				if (thumbimg.length > 0) {
+					thumb = thumbimg[0].currentSrc ? thumbimg[0].currentSrc : thumbimg[0].src;
+					return false
+				}
+			}
+		});
 
 		if (data.medium !== '') {
 			let medium = '';
@@ -284,7 +296,7 @@ build.imageview = function (data, visibleControls) {
 			<div class='arrow_wrapper arrow_wrapper--next'><a id='next'>${build.iconic('caret-right')}</a></div>
 			`;
 
-	return html
+	return { html, thumb }
 
 };
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -67,8 +67,7 @@ photo.load = function(photoID, albumID) {
 		lychee.imageview.show();
 
 		setTimeout(() => {
-			lychee.content.show();
-			photo.preloadNextPrev(photoID)
+			lychee.content.show()
 		}, 300)
 
 	})
@@ -170,9 +169,9 @@ photo.preloadNextPrev = function(photoID) {
 						href = preloadPhoto.medium2x
 					}
 				}
-			} else if (preloadPhoto.type && data.type.indexOf('video') === -1) {
+			} else if (preloadPhoto.type && preloadPhoto.type.indexOf('video') === -1) {
 				// Preload the original size, but only if it's not a video
-				href = url
+				href = preloadPhoto.url
 			}
 
 			if (photo.supportsPrefetch === null) {

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -4,8 +4,9 @@
 
 photo = {
 
-	json  : null,
-	cache : null
+	json             : null,
+	cache            : null,
+	supportsPrefetch : null
 
 };
 
@@ -67,7 +68,7 @@ photo.load = function(photoID, albumID) {
 
 		setTimeout(() => {
 			lychee.content.show();
-			photo.preloadNext(photoID)
+			photo.preloadNextPrev(photoID)
 		}, 300)
 
 	})
@@ -139,33 +140,75 @@ photo.update_display_overlay = function () {
 	}
 };
 
-// Preload the next photo for better response time
-photo.preloadNext = function(photoID) {
+// Preload the next and previous photos for better response time
+photo.preloadNextPrev = function(photoID) {
 	if (album.json &&
 		album.json.photos &&
-		album.getByID(photoID) &&
-		album.getByID(photoID).nextPhoto!=='') {
+		album.getByID(photoID)) {
 
-		let nextPhoto = album.getByID(photoID).nextPhoto;
-		let url       = album.getByID(nextPhoto).url;
-		let medium    = album.getByID(nextPhoto).medium;
-		let href      = url;
-		if (medium != null && medium !== '') {
-			href = medium;
-
-			let medium2x = album.getByID(nextPhoto).medium2x;
-			if (medium2x && medium2x !== '') {
-				// If the currently displayed image uses the 2x variant,
-				// chances are that so will the next one.
-				let imgs=$('img#image');
-				if (imgs.length > 0 && imgs[0].currentSrc != null && imgs[0].currentSrc.includes('@2x.')) {
-					href = medium2x;
-				}
-			}
-		}
+		let previousPhotoID = album.getByID(photoID).previousPhoto;
+		let nextPhotoID = album.getByID(photoID).nextPhoto;
+		let current2x = null;
 
 		$('head [data-prefetch]').remove();
-		$('head').append(`<link data-prefetch rel="prefetch" href="${ href }">`)
+
+		let preload = function(preloadID) {
+			let preloadPhoto  = album.getByID(preloadID);
+			let href = '';
+
+			if (preloadPhoto.medium != null && preloadPhoto.medium !== '') {
+				href = preloadPhoto.medium;
+
+				if (preloadPhoto.medium2x && preloadPhoto.medium2x !== '') {
+					if (current2x === null) {
+						let imgs = $('img#image');
+						current2x = imgs.length > 0 && imgs[0].currentSrc !== null && imgs[0].currentSrc.includes('@2x.')
+					}
+					if (current2x) {
+						// If the currently displayed image uses the 2x variant,
+						// chances are that so will the next one.
+						href = preloadPhoto.medium2x
+					}
+				}
+			} else if (preloadPhoto.type && data.type.indexOf('video') === -1) {
+				// Preload the original size, but only if it's not a video
+				href = url
+			}
+
+			if (photo.supportsPrefetch === null) {
+				// Copied from https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/
+				let DOMTokenListSupports = function(tokenList, token) {
+					if (!tokenList || !tokenList.supports) {
+						return null;
+					}
+					try {
+						return tokenList.supports(token);
+					} catch (e) {
+						if (e instanceof TypeError) {
+							console.log('The DOMTokenList doesn\'t have a supported tokens list');
+						} else {
+							console.error('That shouldn\'t have happened');
+						}
+					}
+				};
+				photo.supportsPrefetch = DOMTokenListSupports(document.createElement('link').relList, 'prefetch');
+			}
+
+			if (photo.supportsPrefetch) {
+				$('head').append(`<link data-prefetch rel="prefetch" href="${ href }">`)
+			} else {
+				// According to https://caniuse.com/#feat=link-rel-prefetch,
+				// as of mid-2019 it's mainly Safari (both on desktop and mobile)
+				(new Image()).src = href
+			}
+		};
+
+		if (nextPhotoID !== '') {
+			preload(nextPhotoID)
+		}
+		if (previousPhotoID !== '') {
+			preload(previousPhotoID)
+		}
 
 	}
 
@@ -289,8 +332,8 @@ photo.delete = function(photoIDs) {
 
 	action.fn = function() {
 
-		let nextPhoto = null;
-		let previousPhoto = null;
+		let nextPhoto = '';
+		let previousPhoto = '';
 
 		basicModal.close();
 
@@ -302,8 +345,12 @@ photo.delete = function(photoIDs) {
 				nextPhoto     = album.getByID(id).nextPhoto;
 				previousPhoto = album.getByID(id).previousPhoto;
 
-				album.getByID(previousPhoto).nextPhoto = nextPhoto;
-				album.getByID(nextPhoto).previousPhoto = previousPhoto
+				if (previousPhoto !== '') {
+					album.getByID(previousPhoto).nextPhoto = nextPhoto
+				}
+				if (nextPhoto !== '') {
+					album.getByID(nextPhoto).previousPhoto = previousPhoto
+				}
 
 			}
 
@@ -315,9 +362,19 @@ photo.delete = function(photoIDs) {
 		albums.refresh();
 
 		// Go to next photo if there is a next photo and
-		// next photo is not the current one. Show album otherwise.
-		if (visible.photo() && nextPhoto!=null && nextPhoto!==photo.getID()) lychee.goto(album.getID() + '/' + nextPhoto);
-		else if (!visible.albums())                                          lychee.goto(album.getID());
+		// next photo is not the current one. Also try the previous one.
+		// Show album otherwise.
+		if (visible.photo()) {
+			if (nextPhoto !== '' && nextPhoto !== photo.getID()) {
+				lychee.goto(album.getID() + '/' + nextPhoto)
+			} else if (previousPhoto !== '' && previousPhoto !== photo.getID()) {
+				lychee.goto(album.getID() + '/' + previousPhoto)
+			} else {
+				lychee.goto(album.getID())
+			}
+		} else if (!visible.albums()) {
+			lychee.goto(album.getID())
+		}
 
 		let params = {
 			photoIDs: photoIDs.join()
@@ -441,8 +498,8 @@ photo.copyTo = function(photoIDs, albumID) {
 
 photo.setAlbum = function(photoIDs, albumID) {
 
-	let nextPhoto = null;
-	let previousPhoto = null;
+	let nextPhoto = '';
+	let previousPhoto = '';
 
 	if (!photoIDs) return false;
 	if (photoIDs instanceof Array===false) photoIDs = [ photoIDs ];
@@ -455,8 +512,12 @@ photo.setAlbum = function(photoIDs, albumID) {
 			nextPhoto     = album.getByID(id).nextPhoto;
 			previousPhoto = album.getByID(id).previousPhoto;
 
-			album.getByID(previousPhoto).nextPhoto = nextPhoto;
-			album.getByID(nextPhoto).previousPhoto = previousPhoto
+			if (previousPhoto !== '') {
+				album.getByID(previousPhoto).nextPhoto = nextPhoto
+			}
+			if (nextPhoto !== '') {
+				album.getByID(nextPhoto).previousPhoto = previousPhoto
+			}
 
 		}
 
@@ -468,9 +529,19 @@ photo.setAlbum = function(photoIDs, albumID) {
 	albums.refresh();
 
 	// Go to next photo if there is a next photo and
-	// next photo is not the current one. Show album otherwise.
-	if (visible.photo() && nextPhoto!=null && nextPhoto!==photo.getID()) lychee.goto(album.getID() + '/' + nextPhoto);
-	else if (!visible.albums())                                          lychee.goto(album.getID());
+	// next photo is not the current one. Also try the previous one.
+	// Show album otherwise.
+	if (visible.photo()) {
+		if (nextPhoto !== '' && nextPhoto !== photo.getID()) {
+			lychee.goto(album.getID() + '/' + nextPhoto)
+		} else if (previousPhoto !== '' && previousPhoto !== photo.getID()) {
+			lychee.goto(album.getID() + '/' + previousPhoto)
+		} else {
+			lychee.goto(album.getID())
+		}
+	} else if (!visible.albums()) {
+		lychee.goto(album.getID())
+	}
 
 	let params = {
 		photoIDs: photoIDs.join(),

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -36,6 +36,9 @@
 		animation-name: zoomIn;
 		animation-duration: .3s;
 		animation-timing-function: $timingBounce;
+		background-size: contain;
+		background-position: center;
+		background-repeat: no-repeat;
 
 		@media (max-width: 640px) {
 			top: 60px;


### PR DESCRIPTION
Fixes #129.

The display of the thumbnail in the photo view while the larger-resolution image is being loaded is implemented using CSS background image (on the `<img>` object, no less). It actually looks pretty cool, I think.

Image prefetching code was extended to request both previous and next images. The prefetch request is initiated only after the main image has finished loading. We no longer prefetch movie files. There's now a fallback for browsers that don't support HTML5 `link rel=prefetch`. While the fallback was trivial, detecting whether it's needed was not. I thought I would be forced to hardcode it based on the user agent, but in the end I found some code that's supposed to detect it at run time.

Code was also extended in places to handle the case of previous or next image being empty, to fully support non-wraparound feature being added to the server.