### PR TITLE
Add .DS_Store to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 package-lock.json
 
 .eslintrc.json
+.DS_Store


### PR DESCRIPTION
MacOS creates .DS_Store files, which contain custom attributues of the folder. These files need to be ignored by git.