### PR TITLE
Selective autoplay

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -262,13 +262,13 @@ build.overlay_image = function (data) {
 	return html;
 };
 
-build.imageview = function (data, visibleControls) {
+build.imageview = function (data, visibleControls, autoplay) {
 
 	let html = '';
 	let thumb = '';
 
 	if (data.type.indexOf('video') > -1) {
-		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' autoplay><source src='${data.url}'>Your browser does not support the video tag.</video>`
+		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' ${autoplay ? 'autoplay' : ''}><source src='${data.url}'>Your browser does not support the video tag.</video>`
 	} else if (data.type.indexOf('raw') > -1) {
 		html += lychee.html`<img id='image' class='${visibleControls === true ? '' : 'full'}' src='img/placeholder.png' draggable='false' alt='big'>`
 	} else {

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -28,7 +28,7 @@ lychee = {
 	image_overlay_default		: false,	// display Overlay like in Lightroom by default
 	image_overlay_type			: 'exif',	// current Overlay display type
 	image_overlay_type_default	: 'exif',	// image overlay type default type
-  map_display				: true,	// display photo coordinates on map
+	map_display					: false,	// display photo coordinates on map
 	landing_page_enabled        : false,    // is landing page enabled ?
 	delete_imported				: false,
 
@@ -166,7 +166,7 @@ lychee.init = function() {
 			lychee.image_overlay				= lychee.image_overlay_default;
 			lychee.image_overlay_type			= (!data.config.image_overlay_type) ? 'exif' : data.config.image_overlay_type;
 			lychee.image_overlay_type_default	= lychee.image_overlay_type;
-			lychee.map_display				= (data.config.map_display && data.config.map_display === '1')  || false;
+			lychee.map_display					= (data.config.map_display && data.config.map_display === '1')  || false;
 			lychee.default_license				= data.config.default_license	|| 'none';
 			lychee.css							= data.config.css				|| '';
 			lychee.full_photo					= (data.config.full_photo == null) || (data.config.full_photo === '1');
@@ -204,7 +204,7 @@ lychee.init = function() {
 			lychee.image_overlay				= (data.config.image_overlay && data.config.image_overlay === '1') || false;
 			lychee.image_overlay_type			= (!data.config.image_overlay_type) ? 'exif' : data.config.image_overlay_type;
 			lychee.image_overlay_type_default	= lychee.image_overlay_type;
-			lychee.map_display				= (data.config.map_display && data.config.map_display === '1') || false;
+			lychee.map_display					= (data.config.map_display && data.config.map_display === '1') || false;
 
 			// console.log(lychee.full_photo);
 			lychee.setMode('public');
@@ -283,16 +283,16 @@ lychee.logout = function() {
 
 };
 
-lychee.goto = function(url = '') {
+lychee.goto = function(url = '', autoplay = true) {
 
 	url = '#' + url;
 
 	history.pushState(null, null, url);
-	lychee.load()
+	lychee.load(autoplay)
 
 };
 
-lychee.load = function() {
+lychee.load = function(autoplay = true) {
 
 	let albumID	= '';
 	let photoID	= '';
@@ -315,7 +315,7 @@ lychee.load = function() {
 			lychee.content.hide();
 			album.load(albumID, true)
 		}
-		photo.load(photoID, albumID);
+		photo.load(photoID, albumID, autoplay);
 		lychee.footer_hide();
 
 	} else if (albumID) {

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -22,15 +22,15 @@ photo.getID = function() {
 
 };
 
-photo.load = function(photoID, albumID) {
+photo.load = function(photoID, albumID, autoplay) {
 
 	const checkContent = function() {
-		if (album.json!=null && album.json.photos) photo.load(photoID, albumID);
+		if (album.json!=null && album.json.photos) photo.load(photoID, albumID, autoplay);
 		else                  setTimeout(checkContent, 100)
 	};
 
 	const checkPasswd = function() {
-		if (password.value!=='') photo.load(photoID, albumID);
+		if (password.value!=='') photo.load(photoID, albumID, autoplay);
 		else                     setTimeout(checkPasswd, 200)
 	};
 
@@ -63,7 +63,7 @@ photo.load = function(photoID, albumID) {
 		photo.json.album = albumID;
 
 		if (!visible.photo()) view.photo.show();
-		view.photo.init();
+		view.photo.init(autoplay);
 		lychee.imageview.show();
 
 		setTimeout(() => {
@@ -243,7 +243,7 @@ photo.previous = function(animate) {
 
 		setTimeout(() => {
 			if (photo.getID()===false) return false;
-			lychee.goto(album.getID() + '/' + album.getByID(photo.getID()).previousPhoto)
+			lychee.goto(album.getID() + '/' + album.getByID(photo.getID()).previousPhoto, false)
 		}, delay)
 
 	}
@@ -274,7 +274,7 @@ photo.next = function(animate) {
 
 		setTimeout(() => {
 			if (photo.getID()===false) return false;
-			lychee.goto(album.getID() + '/' + album.getByID(photo.getID()).nextPhoto)
+			lychee.goto(album.getID() + '/' + album.getByID(photo.getID()).nextPhoto, false)
 		}, delay)
 
 	}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -443,7 +443,7 @@ sidebar.has_location = function(structure) {
 
 	if (structure==null || structure==='' || structure===false) return false;
 
-  let _has_location = false;
+	let _has_location = false;
 
 	structure.forEach(function(section) {
 
@@ -490,7 +490,7 @@ sidebar.render = function(structure) {
 
 			if ((_has_latitude) && (_has_longitude) && (lychee.map_display)) {
 				_html += `
-						 <div id="mapid" style="margin: 10px 0px 0px 20px; height: 180px; width: calc(100% - 40px); float: left"></div>
+						 <div id="mapid"></div>
 						 `;
 			}
 		}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -272,10 +272,14 @@ sidebar.createStructure.photo = function(data) {
 			rows  : [
 				{ title: lychee.locale['PHOTO_LATITUDE'],    kind:'latitude',   value: (data.latitude) ? DecimalToDegreeMinutesSeconds(data.latitude, true) : '' },
 				{ title: lychee.locale['PHOTO_LONGITUDE'],    kind:'longitude',   value: (data.longitude) ? DecimalToDegreeMinutesSeconds(data.longitude, false) : ''},
-				{ title: lychee.locale['PHOTO_ALTITUDE'],    kind:'altitude',   value: (data.altitude) ?  data.altitude + 'm' : ''},
-				{ title: lychee.locale['PHOTO_IMGDIRECTION'],    kind:'imgDirection',   value: (data.imgDirection) ?  data.imgDirection + '°' : ''}
+				// No point in displaying sub-mm precision; 10cm is more than enough.
+				{ title: lychee.locale['PHOTO_ALTITUDE'],    kind:'altitude',   value: (data.altitude) ? (Math.round(parseFloat(data.altitude) * 10) / 10).toString() + 'm' : ''}
 			]
 		};
+		if (data.imgDirection) {
+			// No point in display sub-degree precision.
+			structure.location.rows.push({ title: lychee.locale['PHOTO_IMGDIRECTION'], kind:'imgDirection', value: Math.round(data.imgDirection).toString() + '°'})
+		}
 	} else {
 		structure.location = {}
 	}

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -515,7 +515,7 @@ view.album = {
 
 view.photo = {
 
-	init: function () {
+	init: function (autoplay) {
 
 		multiselect.clearSelection();
 
@@ -525,7 +525,7 @@ view.photo = {
 		view.photo.title();
 		view.photo.star();
 		view.photo.public();
-		view.photo.photo();
+		view.photo.photo(autoplay);
 
 		photo.json.init = 1
 
@@ -664,9 +664,9 @@ view.photo = {
 
 	},
 
-	photo: function () {
+	photo: function (autoplay) {
 
-		let ret = build.imageview(photo.json, visible.header());
+		let ret = build.imageview(photo.json, visible.header(), autoplay);
 		lychee.imageview.html(ret.html);
 		view.photo.onresize();
 

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -745,8 +745,8 @@ view.photo = {
 			var mymap = L.map('mapid').setView([photo.json.latitude, photo.json.longitude], 13);
 
 			// Add plain OpenStreetMap Layer
-			L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-				attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+			L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+				attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
 			}).addTo(mymap);
 
 			if (!photo.json.imgDirection || photo.json.imgDirection === '') {

--- a/styles/main/_sidebar.scss
+++ b/styles/main/_sidebar.scss
@@ -214,4 +214,11 @@
 		transform: scale(1);
 	}
 
+	#mapid {
+		margin: 10px 0px 0px 20px;
+		height: 180px;
+		width: calc(100% - 40px);
+		float: left;
+	}
+
 }


### PR DESCRIPTION
Do not autoplay videos accessed via the previous or next button (or swipe left/right). There's no way for the user to tell ahead of time that they are video file so autoplay may be undesirable.

Also clean up the new map display:
* limit the precision of altitude and direction to something sensible
* display direction only if present
* use https to access the OSM data
* move style to the style file
* make the front end default match the server default
* indentation fixes