### PR TITLE
Added function to apply translations to the header

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -232,7 +232,7 @@ header.setEditable = function(editable) {
 
 };
 
-header.applyTransduction = function () {
+header.applyTranslations = function () {
 
 	let selector_locale = {
 		'#button_signin'         : 'SIGN_IN',

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -231,3 +231,30 @@ header.setEditable = function(editable) {
 	return true
 
 };
+
+header.applyTransduction = function () {
+
+	let selector_locale = {
+		'#button_signin'         : 'SIGN_IN',
+		'#button_settings'       : 'SETTINGS',
+		'#button_info_album'     : 'ABOUT_ALBUM',
+		'#button_info'           : 'ABOUT_PHOTO',
+		'.button_add'            : 'ADD',
+		'#button_move_album'     : 'ABOUT_ALBUM',
+		'#button_move'           : 'MOVE',
+		'#button_trash_album'    : 'DELETE_ALBUM',
+		'#button_trash'          : 'DELETE',
+		'#button_archive'        : 'DOWNLOAD_ALBUM',
+		'#button_star'           : 'STAR_PHOTO',
+		'#button_back_home'      : 'CLOSE_ALBUM',
+		'#button_fs_album_enter' : 'FULLSCREEN_ENTER',
+		'#button_fs_enter'       : 'FULLSCREEN_ENTER',
+		'#button_share'          : 'SHARE_PHOTO',
+		'#button_share_album'    : 'SHARE_ALBUM'
+	}
+
+	for (let selector in selector_locale) {
+		header.dom(selector).prop('title', lychee.locale[selector_locale[selector]])
+	}
+
+}

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -240,7 +240,7 @@ header.applyTranslations = function () {
 		'#button_info_album'     : 'ABOUT_ALBUM',
 		'#button_info'           : 'ABOUT_PHOTO',
 		'.button_add'            : 'ADD',
-		'#button_move_album'     : 'ABOUT_ALBUM',
+		'#button_move_album'     : 'MOVE_ALBUM',
 		'#button_move'           : 'MOVE',
 		'#button_trash_album'    : 'DELETE_ALBUM',
 		'#button_trash'          : 'DELETE',

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -145,8 +145,10 @@ lychee.init = function() {
 			lychee.locale[key] = data.locale[key]
 		}
 
-		// Apply translations to the header
-		header.applyTranslations();
+		if (!lychee.api_V2) {
+			// Apply translations to the header
+			header.applyTranslations();
+		}
 
 		// Check status
 		// 0 = No configuration

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -145,6 +145,9 @@ lychee.init = function() {
 			lychee.locale[key] = data.locale[key]
 		}
 
+		// Apply translations to the header
+		header.applyTransduction();
+
 		// Check status
 		// 0 = No configuration
 		// 1 = Logged out

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -146,7 +146,7 @@ lychee.init = function() {
 		}
 
 		// Apply translations to the header
-		header.applyTransduction();
+		header.applyTranslations();
 
 		// Check status
 		// 0 = No configuration

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -803,7 +803,7 @@ view.settings = {
 
 	title: function () {
 
-		lychee.setTitle('Settings', false)
+		lychee.setTitle(lychee.locale['SETTINGS'], false)
 	},
 
 	clearContent: function () {


### PR DESCRIPTION
Hi,

I saw that several translations do not work, so I added this change to be displayed.

But I do not apply all the translations because multiple words like "More", "Full configuration", "Search" among others that do not exist in "php / Locale / English.php" and I would like to add them but I don't know if I also have to add them to "Lychee-front / scripts / main / lychee_locale.js"? and I also don't know if there would be a problem with this new translation in the other languages? (Italian.php, German.php, etc).

Could you help me with these questions before changing anything.

Thank you.