### PR TITLE
Added basic support for uploading images by pasting from clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 
 .eslintrc.json
 .DS_Store
+.idea

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -154,29 +154,29 @@ $(document).ready(function() {
 	// Paste upload
 	.on('paste', function (e) {
 		if (e.originalEvent.clipboardData.items) {
-			if (!album.isUploadable()) {
-				return false;
+			const items = e.originalEvent.clipboardData.items;
+			let filesToUpload = [];
+
+			// Search clipboard items for an image
+			for (let i = 0; i < items.length; i++) {
+				if (items[i].type.indexOf('image') !== -1 || items[i].type.indexOf('video') !== -1) {
+					filesToUpload.push(items[i].getAsFile());
+				}
 			}
 
-			// Close open overlays or views which are correlating with the upload
-			if (visible.photo()) lychee.goto(album.getID());
-			if (visible.contextMenu()) contextMenu.close();
-
-			if (e.originalEvent.clipboardData.items.length > 0) {
-				const items = e.originalEvent.clipboardData.items;
-				let imagesToUpload = [];
-
-				// Search clipboard items for an image
-				for (let i = 0; i < items.length; i++) {
-					if (items[i].type.indexOf('image') !== -1) {
-						imagesToUpload.push(items[i].getAsFile());
-					}
+			if (filesToUpload.length > 0) {
+				if (!album.isUploadable()) {
+					return false;
 				}
 
-				upload.start.local(imagesToUpload);
-			}
+				// Close open overlays or views which are correlating with the upload
+				if (visible.photo()) lychee.goto(album.getID());
+				if (visible.contextMenu()) contextMenu.close();
 
-			return false;
+				upload.start.local(filesToUpload);
+
+				return false;
+			}
 		}
 	})
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -165,17 +165,25 @@ $(document).ready(function() {
 			}
 
 			if (filesToUpload.length > 0) {
-				if (!album.isUploadable()) {
-					return false;
-				}
+				if (!album.isUploadable())
+					return;
 
 				// Close open overlays or views which are correlating with the upload
-				if (visible.photo()) lychee.goto(album.getID());
-				if (visible.contextMenu()) contextMenu.close();
 
-				upload.start.local(filesToUpload);
+				if (visible.photo())
+					lychee.goto(album.getID());
+					
+				if (visible.contextMenu())
+					contextMenu.close();
 
-				return false;
+				if (basicModal.visible() || visible.leftMenu())
+					return;
+																
+				if (visible.album() || visible.albums()) {
+					upload.start.local(filesToUpload);
+
+					return false;
+				}
 			}
 		}
 	})

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -151,6 +151,35 @@ $(document).ready(function() {
 
 	})
 
+	// Paste upload
+	.on('paste', function (e) {
+		if (e.originalEvent.clipboardData.items) {
+			if (!album.isUploadable()) {
+				return false;
+			}
+
+			// Close open overlays or views which are correlating with the upload
+			if (visible.photo()) lychee.goto(album.getID());
+			if (visible.contextMenu()) contextMenu.close();
+
+			if (e.originalEvent.clipboardData.items.length > 0) {
+				const items = e.originalEvent.clipboardData.items;
+				let imagesToUpload = [];
+
+				// Search clipboard items for an image
+				for (let i = 0; i < items.length; i++) {
+					if (items[i].type.indexOf('image') !== -1) {
+						imagesToUpload.push(items[i].getAsFile());
+					}
+				}
+
+				upload.start.local(imagesToUpload);
+			}
+
+			return false;
+		}
+	})
+
 	// Fullscreen
 	.on('fullscreenchange mozfullscreenchange webkitfullscreenchange msfullscreenchange', lychee.fullscreenUpdate);
 


### PR DESCRIPTION
#### Associated Feature Request: #154 

### Description:
This PR adds support for uploading images by pasting them from clipboard into Lychee.
Tested in Chrome 77 and Firefox 69 on Windows 10.

**Important:** This does not add support for uploading images by pasting an **URL** from clipboard, as requested in the Feature Request.
That's because I found it unnecessary to have this feature when you could just use the normal "+" -\> "Import from Link" method

**Also Important:** On Windows 10, I've tried to copy an image file in Explorer and paste it into Lychee. This didn't work for some reason. But what definitely works is going to a random website, clicking on an image, clicking "Copy Image" and then pasting it into Lychee!

### Example Use:
1. Go on a random website with images (for example [unsplash.com](https://unsplash.com))
2. Click on an image you want to import to Lychee
3. Right-Click on the image and choose "Copy Image"
4. Go to Lychee
5. Press "Strg+V"