### PR TITLE
Various fixes

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -202,7 +202,6 @@ contextMenu.photo = function(photoID, e) {
 		{ title: build.iconic('tag') + lychee.locale['TAGS'], fn: () => photo.editTags([ photoID ]) },
 		{ },
 		{ title: build.iconic('pencil') + lychee.locale['RENAME'], fn: () => photo.setTitle([ photoID ]) },
-		{ title: build.iconic('layers') + lychee.locale['DUPLICATE'], fn: () => photo.duplicate([ photoID ]) },
 		{ title: build.iconic('layers') + lychee.locale['COPY_TO'], fn: () => { basicContext.close(); contextMenu.move([ photoID ], e, photo.copyTo, 'UNSORTED') } },
 		{ title: build.iconic('folder') + lychee.locale['MOVE'], fn: () => { basicContext.close(); contextMenu.move([ photoID ], e, photo.setAlbum, 'UNSORTED') } },
 		{ title: build.iconic('trash') + lychee.locale['DELETE'], fn: () => photo.delete([ photoID ]) },
@@ -264,7 +263,6 @@ contextMenu.photoMulti = function(photoIDs, e) {
 		{ title: build.iconic('tag') + lychee.locale['TAGS_ALL'], fn: () => photo.editTags(photoIDs) },
 		{ },
 		{ title: build.iconic('pencil') + lychee.locale['RENAME_ALL'], fn: () => photo.setTitle(photoIDs) },
-		{ title: build.iconic('layers') + lychee.locale['DUPLICATE_ALL'], fn: () => photo.duplicate(photoIDs) },
 		{ title: build.iconic('layers') + lychee.locale['COPY_ALL_TO'], fn: () => { basicContext.close(); contextMenu.move(photoIDs, e, photo.copyTo, 'UNSORTED') } },
 		{ title: build.iconic('folder') + lychee.locale['MOVE_ALL'], fn: () => { basicContext.close(); contextMenu.move(photoIDs, e, photo.setAlbum, 'UNSORTED') } },
 		{ title: build.iconic('trash') + lychee.locale['DELETE_ALL'], fn: () => photo.delete(photoIDs) },
@@ -362,8 +360,9 @@ contextMenu.move = function(IDs, e, callback, kind = 'UNSORTED', display_root = 
 					exclude.push(sub[s])
 			}
 			if (visible.album()) {
-				if (callback !== album.merge) {
-					// For merging, don't exclude the parent.
+				// For merging, don't exclude the parent.
+				// For photo copy, don't exclude the current album.
+				if (callback !== album.merge && callback !== photo.copyTo) {
 					exclude.push(album.getID().toString())
 				}
 				if (IDs.length === 1 && IDs[0] === album.getID() && album.getParent() && callback === album.setAlbum) {

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -399,8 +399,12 @@ contextMenu.move = function(IDs, e, callback, kind = 'UNSORTED', display_root = 
 
 		}
 
-		items.unshift({});
-		items.unshift({ title: lychee.locale['NEW_ALBUM'], fn: () => album.add(IDs, callback) });
+		// Don't allow to move the current album to a newly created subalbum
+		// (creating a cycle).
+		if (IDs.length !== 1 || IDs[0] !== (album.json ? album.json.id : null) || callback !== album.setAlbum) {
+			items.unshift({});
+			items.unshift({ title: lychee.locale['NEW_ALBUM'], fn: () => album.add(IDs, callback) })
+		}
 
 		basicContext.show(items, e.originalEvent, contextMenu.close)
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -283,33 +283,6 @@ photo.next = function(animate) {
 
 };
 
-photo.duplicate = function(photoIDs, callback = null) {
-
-	if (!photoIDs) return false;
-	if (photoIDs instanceof Array===false) photoIDs = [ photoIDs ];
-
-	albums.refresh();
-
-	let params = {
-		photoIDs: photoIDs.join()
-	};
-
-	api.post('Photo::duplicate', params, function(data) {
-
-		if (data!==true){
-			lychee.error(null, params, data);
-		}
-		else {
-			album.load(album.getID());
-			if (callback != null) {
-				callback();
-			}
-		}
-
-	})
-
-};
-
 photo.delete = function(photoIDs) {
 
 	let action     = {};
@@ -490,11 +463,31 @@ photo.setTitle = function(photoIDs) {
 
 photo.copyTo = function(photoIDs, albumID) {
 
-	const action = function()
-	{
-		photo.setAlbum(photoIDs,albumID);
+	if (!photoIDs) return false;
+	if (photoIDs instanceof Array===false) photoIDs = [ photoIDs ];
+
+	let params = {
+		photoIDs: photoIDs.join(),
+		albumID
 	};
-	photo.duplicate(photoIDs, action);
+
+	api.post('Photo::duplicate', params, function(data) {
+
+		if (data !== true){
+			lychee.error(null, params, data)
+		}
+		else {
+			if (lychee.api_V2 || albumID === album.getID()) {
+				album.reload()
+			} else {
+				// Lychee v3 does not support the albumID argument to
+				// Photo::duplicate so we need to do it manually, which is
+				// imperfect, as it moves the source photos, not the duplicates.
+				photo.setAlbum(photoIDs, albumID)
+			}
+		}
+
+	})
 };
 
 photo.setAlbum = function(photoIDs, albumID) {


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee-Laravel/issues/362.
Fixes #151.

* Disable New Album when moving the current album
* Fold the redundant Duplicate feature into Copy to...
* Use the new albumID argument to Photo::duplicate so that the duplicate rather than the original moves (depends on https://github.com/LycheeOrg/Lychee-Laravel/pull/364)