### PR TITLE
Correct the updates of the counts in the sidebar

### DIFF
--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -119,6 +119,10 @@ sidebar.changeAttr = function(attr, value = '-', dangerouslySetInnerHTML = false
 
 };
 
+sidebar.hideAttr = function(attr) {
+	sidebar.dom('.attr_' + attr).closest('tr').hide()
+};
+
 sidebar.secondsToHMS = function(d) {
 	d = Number(d);
 	var h = Math.floor(d / 3600);

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -288,9 +288,6 @@ view.album = {
 
 		delete: function (photoID, justify = false) {
 
-			if (album.json && album.json.num) {
-				album.json.num--;
-			}
 			$('.photo[data-id="' + photoID + '"]').css('opacity', 0).animate({
 				width: 0,
 				marginLeft: 0
@@ -298,8 +295,23 @@ view.album = {
 				$(this).remove();
 				// Only when search is not active
 				if (album.json) {
-					if (album.json.num) {
-						view.album.num();
+					if (visible.sidebar()) {
+						videoCount = 0;
+						$.each(album.json.photos, function () {
+							if (this.type && this.type.indexOf('video') > -1) {
+								videoCount++;
+							}
+						});
+						if (album.json.photos.length - videoCount > 0) {
+							sidebar.changeAttr('images', album.json.photos.length - videoCount)
+						} else {
+							sidebar.hideAttr('images')
+						}
+						if (videoCount > 0) {
+							sidebar.changeAttr('videos', videoCount)
+						} else {
+							sidebar.hideAttr('videos')
+						}
 					}
 					if (album.json.photos.length <= 0) {
 						lychee.content.find('.divider').remove()
@@ -319,7 +331,18 @@ view.album = {
 				marginLeft: 0
 			}, 300, function () {
 				$(this).remove();
-				if (album.json && album.json.albums.length <= 0) lychee.content.find('.divider').remove()
+				if (album.json) {
+					if (album.json.albums.length <= 0) {
+						lychee.content.find('.divider').remove()
+					}
+					if (visible.sidebar()) {
+						if (album.json.albums.length > 0) {
+							sidebar.changeAttr('subalbums', album.json.albums.length)
+						} else {
+							sidebar.hideAttr('subalbums')
+						}
+					}
+				}
 			})
 
 		},
@@ -443,12 +466,6 @@ view.album = {
 		}
 
 		sidebar.changeAttr('license', license)
-
-	},
-
-	num: function () {
-
-		sidebar.changeAttr('images', album.json.num)
 
 	},
 


### PR DESCRIPTION
Another overdue patch. Cleans up and fixes missing cases in the updating of subalbum/image/video counts in the sidebar after delete operations. In the process gets rid of a completely unnecessary `album.json.num` so that in the future we can remove it from the server as well (it's only needed for smart albums).