### PR TITLE
Bugfix

### DIFF
--- a/scripts/main/leftMenu.js
+++ b/scripts/main/leftMenu.js
@@ -23,18 +23,18 @@ leftMenu.build = function () {
 	if (lychee.api_V2)
 	{
 		html += lychee.html`
-		<a class="linkMenu" id="button_users">${    build.iconic('person') } ${             lychee.locale['USERS'] } </a>
-		<a class="linkMenu" id="button_sharing">${  build.iconic('cloud') } ${              lychee.locale['SHARING'] }</a>`
+		<a class="linkMenu" id="button_users">${    build.iconic('person') }${             lychee.locale['USERS'] } </a>
+		<a class="linkMenu" id="button_sharing">${  build.iconic('cloud') }${              lychee.locale['SHARING'] }</a>`
 	}
 	html += lychee.html`
-		<a class="linkMenu" id="button_logs">${         build.iconic('align-left') } ${     lychee.locale['LOGS'] }</a>
-		<a class="linkMenu" id="button_diagnostics">${  build.iconic('wrench') } ${         lychee.locale['DIAGNOSTICS'] }</a>
-		<a class="linkMenu" id="button_about">${        build.iconic('info') } ${           lychee.locale['ABOUT_LYCHEE'] }</a>
-		<a class="linkMenu" id="button_signout">${      build.iconic('account-logout') } ${ lychee.locale['SIGN_OUT'] }</a>`;
+		<a class="linkMenu" id="button_logs">${         build.iconic('align-left') }${     lychee.locale['LOGS'] }</a>
+		<a class="linkMenu" id="button_diagnostics">${  build.iconic('wrench') }${         lychee.locale['DIAGNOSTICS'] }</a>
+		<a class="linkMenu" id="button_about">${        build.iconic('info') }${           lychee.locale['ABOUT_LYCHEE'] }</a>
+		<a class="linkMenu" id="button_signout">${      build.iconic('account-logout') }${ lychee.locale['SIGN_OUT'] }</a>`;
 	if (lychee.api_V2 && lychee.update_available)
 	{
 		html += lychee.html`
-		<a class="linkMenu" id="button_update">${ build.iconic('timer')} ${ lychee.locale['UPDATE_AVAILABLE']}</a>
+		<a class="linkMenu" id="button_update">${ build.iconic('timer')}${ lychee.locale['UPDATE_AVAILABLE']}</a>
 		`
 	}
 	leftMenu._dom.html(html)

--- a/styles/main/_leftMenu.scss
+++ b/styles/main/_leftMenu.scss
@@ -20,6 +20,10 @@
 	color: #818181;
 	display: block;
 	transition: 0.3s;
+
+	&.linkMenu {
+		white-space: nowrap;
+	}
 }
 
 /* When you mouse over the navigation links, change their color */


### PR DESCRIPTION
Fix #177

Added a min-width property for blocklevel left menu items so that collapsing
the menu doesn't cause the menu item labels to cascade to a new line.

Also removed spaces between menu items and icons because this causes
misalignment.