### PR TITLE
Fix toggle of header

### DIFF
--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -105,9 +105,20 @@ $(document).ready(function() {
 
 			// Fullscreen on mobile
 			.on('touchend', '#imageview #image', function(e) {
-				if (swipe.obj==null || (swipe.offsetX>=-5&&swipe.offsetX<=5)) {
-					if (visible.header()) header.hide(e);
-					else                  header.show()
+
+				// prevent triggering event 'mousemove'
+				e.preventDefault();
+
+				if ((swipe.obj==null) || ((Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5))) {
+					// Toogle header only if we're not moving to next/previous photo;
+					// In this case, swipe.preventNextHeaderToggle is set to true
+					if((swipe.preventNextHeaderToggle==null) || (swipe.preventNextHeaderToggle==false)) {
+						if (visible.header()) header.hide(e);
+						else                  header.show();
+					}
+
+					// For next 'touchend', behave again as normal and toogle header
+					swipe.preventNextHeaderToggle = false;
 				}
 			});
 		$('#imageview')

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -109,12 +109,15 @@ $(document).ready(function() {
 				// prevent triggering event 'mousemove'
 				e.preventDefault();
 
-				if ((swipe.obj==null) || ((Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5))) {
+				if ((typeof swipe.obj === undefined) || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
 					// Toogle header only if we're not moving to next/previous photo;
 					// In this case, swipe.preventNextHeaderToggle is set to true
-					if((swipe.preventNextHeaderToggle==null) || (swipe.preventNextHeaderToggle==false)) {
-						if (visible.header()) header.hide(e);
-						else                  header.show();
+					if((typeof swipe.preventNextHeaderToggle === undefined) || (!swipe.preventNextHeaderToggle)) {
+						if (visible.header()) {
+							header.hide(e);
+						} else {
+						  header.show();
+						}
 					}
 
 					// For next 'touchend', behave again as normal and toogle header

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -109,10 +109,10 @@ $(document).ready(function() {
 				// prevent triggering event 'mousemove'
 				e.preventDefault();
 
-				if ((typeof swipe.obj === undefined) || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
+				if ((typeof swipe.obj === 'undefined') || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
 					// Toogle header only if we're not moving to next/previous photo;
 					// In this case, swipe.preventNextHeaderToggle is set to true
-					if((typeof swipe.preventNextHeaderToggle === undefined) || (!swipe.preventNextHeaderToggle)) {
+					if((typeof swipe.preventNextHeaderToggle === 'undefined') || (!swipe.preventNextHeaderToggle)) {
 						if (visible.header()) {
 							header.hide(e);
 						} else {

--- a/scripts/main/swipe.js
+++ b/scripts/main/swipe.js
@@ -8,7 +8,8 @@ let swipe = {
 	tolerance_X    : 150,
 	tolerance_Y    : 250,
 	offsetX        : 0,
-	offsetY        : 0
+	offsetY        : 0,
+	preventNextHeaderToggle : false
 
 };
 
@@ -65,11 +66,21 @@ swipe.stop = function(e, left, right) {
 
 	} else if (e.x<=-swipe.tolerance_X) {
 
-		left(true)
+		left(true);
+
+		// 'touchend' will be called after 'swipeEnd'
+		// in case of moving to next image, we want to skip
+		// the toggling of the header
+		swipe.preventNextHeaderToggle = true;
 
 	} else if (e.x>=swipe.tolerance_X) {
 
-		right(true)
+		right(true);
+
+		// 'touchend' will be called after 'swipeEnd'
+		// in case of moving to next image, we want to skip
+		// the toggling of the header
+		swipe.preventNextHeaderToggle = true;
 
 	} else {
 


### PR DESCRIPTION
Fix toggling of header in 2 cases

1. single touch does not toggle header (#174)
Event 'mousemove' gets called after a single touch and 'mousemove' makes header appear; Solution is to prevent event 'mousemove' to be called after 'touchend'

2. swipe forward / backward toogles header
Swiping forward / backward triggers 'touchend' event, which toggles the header. Solution is to prevent toggling if 'swipeend' triggered loading of previous/next photo