### PR TITLE
Support fire tv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       dist: xenial #16.04
 
 node_js:
-  - 13
+  - "node"
 
 before_script:
   - npm install

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -329,7 +329,9 @@ paths.TVCSS = {
 gulp.task('TVCSS--styles', function () {
 	return gulp.src(paths.TVCSS.src)
 		.on('error', catchError)
-		.pipe(gulp.dest('../dist'))
+    .pipe(plugins.concat('TV.css', {newLine: "\n"}))
+		.pipe(plugins.autoprefixer('last 4 versions', '> 5%'))
+		.pipe(gulp.dest('../dist/'))
 });
 
 /* Images ----------------------------------------- */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,6 +317,21 @@ gulp.task('page--styles', function() {
 
 });
 
+
+/* Page -----------------------------------------  */
+
+paths.TVCSS = {
+	src: [
+		'./styles/devices/TV.scss'
+	]
+};
+
+gulp.task('TVCSS--styles', function () {
+	return gulp.src(paths.TVCSS.src)
+		.on('error', catchError)
+		.pipe(gulp.dest('../dist'))
+});
+
 /* Images ----------------------------------------- */
 
 
@@ -380,7 +395,7 @@ gulp.task('clean', function() {
 gulp.task('default', gulp.series(gulp.parallel('view--svg', 'view--scripts',
 												'main--svg', 'main--scripts', 'main--styles',
 												'frame--scripts', 'frame--styles',
-												'landing--scripts', 'landing--styles', 'page--styles',
+												'landing--scripts', 'landing--styles', 'page--styles', 'TVCSS--styles',
 												'images--copy', 'leafletMarkerclusterMapFile--copy',
                         'leafletMarkerclusterSourceFiles--copy'
 	), 'clean'));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "babel-preset-env": "^1.7.0",
-    "basicmodal": "^3.3.8",
+    "basicmodal": "github:LycheeOrg/basicmodal#master",
     "gulp": "^4.0.0",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-babel": "^6.1.2",

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -183,6 +183,19 @@ album.load = function (albumID, refresh = false) {
 				lychee.animate(lychee.content, 'contentZoomIn');
 				header.setMode('album');
 			}
+
+			tabindex.makeFocusable(lychee.content);
+			// Put focus on first element - either album or photo
+			first_album = $(".album:first");
+			if (first_album.length !== 0) {
+				first_album.focus();
+			} else {
+				first_photo = $(".photo:first");
+				if (first_photo.length !== 0) {
+					first_photo.focus();
+				}
+			}
+
 		}, waitTime)
 	};
 
@@ -199,7 +212,19 @@ album.load = function (albumID, refresh = false) {
 				})
 			})
 		} else {
-			processData(data)
+			processData(data);
+
+			tabindex.makeFocusable(lychee.content);
+			// Put focus on first element - either album or photo
+			first_album = $(".album:first");
+			if (first_album.length !== 0) {
+				first_album.focus();
+			} else {
+				first_photo = $(".photo:first");
+				if (first_photo.length !== 0) {
+					first_photo.focus();
+				}
+			}
 		}
 	})
 

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -185,16 +185,19 @@ album.load = function (albumID, refresh = false) {
 			}
 
 			tabindex.makeFocusable(lychee.content);
-			// Put focus on first element - either album or photo
-			first_album = $(".album:first");
-			if (first_album.length !== 0) {
-				first_album.focus();
-			} else {
-				first_photo = $(".photo:first");
-				if (first_photo.length !== 0) {
-					first_photo.focus();
+			if (lychee.active_focus_on_page_load) {
+				// Put focus on first element - either album or photo
+				first_album = $(".album:first");
+				if (first_album.length !== 0) {
+					first_album.focus();
+				} else {
+					first_photo = $(".photo:first");
+					if (first_photo.length !== 0) {
+						first_photo.focus();
+					}
 				}
 			}
+
 
 		}, waitTime)
 	};
@@ -215,14 +218,17 @@ album.load = function (albumID, refresh = false) {
 			processData(data);
 
 			tabindex.makeFocusable(lychee.content);
-			// Put focus on first element - either album or photo
-			first_album = $(".album:first");
-			if (first_album.length !== 0) {
-				first_album.focus();
-			} else {
-				first_photo = $(".photo:first");
-				if (first_photo.length !== 0) {
-					first_photo.focus();
+
+			if(lychee.active_focus_on_page_load) {
+				// Put focus on first element - either album or photo
+				first_album = $(".album:first");
+				if (first_album.length !== 0) {
+					first_album.focus();
+				} else {
+					first_photo = $(".photo:first");
+					if (first_photo.length !== 0) {
+						first_photo.focus();
+					}
 				}
 			}
 		}

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -186,7 +186,7 @@ album.load = function (albumID, refresh = false) {
 			tabindex.makeFocusable(lychee.content);
 			if (lychee.active_focus_on_page_load) {
 				// Put focus on first element - either album or photo
-				first_album = $(".album:first");
+				let first_album = $(".album:first");
 				if (first_album.length !== 0) {
 					first_album.focus();
 				} else {

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -40,16 +40,20 @@ albums.load = function () {
 				lychee.animate(lychee.content, 'contentZoomIn');
 
 				tabindex.makeFocusable(lychee.content);
-				// Put focus on first element - either album or photo
-				first_album = $(".album:first");
-				if (first_album.length !== 0) {
-					first_album.focus();
-				} else {
-					first_photo = $(".photo:first");
-					if (first_photo.length !== 0) {
-						first_photo.focus();
+
+				if(lychee.active_focus_on_page_load) {
+					// Put focus on first element - either album or photo
+					first_album = $(".album:first");
+					if (first_album.length !== 0) {
+						first_album.focus();
+					} else {
+						first_photo = $(".photo:first");
+						if (first_photo.length !== 0) {
+							first_photo.focus();
+						}
 					}
 				}
+
 				setTimeout(() => {
 					lychee.footer_show();
 				},
@@ -66,16 +70,20 @@ albums.load = function () {
 			lychee.animate(lychee.content, 'contentZoomIn');
 
 			tabindex.makeFocusable(lychee.content);
-			// Put focus on first element - either album or photo
-			first_album = $(".album:first");
-			if (first_album.length !== 0) {
-				first_album.focus();
-			} else {
-				first_photo = $(".photo:first");
-				if (first_photo.length !== 0) {
-					first_photo.focus();
+
+			if(lychee.active_focus_on_page_load) {
+				// Put focus on first element - either album or photo
+				first_album = $(".album:first");
+				if (first_album.length !== 0) {
+					first_album.focus();
+				} else {
+					first_photo = $(".photo:first");
+					if (first_photo.length !== 0) {
+						first_photo.focus();
+					}
 				}
 			}
+
 		}, 300)
 
 	}

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -43,7 +43,7 @@ albums.load = function () {
 
 				if(lychee.active_focus_on_page_load) {
 					// Put focus on first element - either album or photo
-					first_album = $(".album:first");
+					let first_album = $(".album:first");
 					if (first_album.length !== 0) {
 						first_album.focus();
 					} else {

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -38,6 +38,18 @@ albums.load = function () {
 				header.setMode('albums');
 				view.albums.init();
 				lychee.animate(lychee.content, 'contentZoomIn');
+
+				tabindex.makeFocusable(lychee.content);
+				// Put focus on first element - either album or photo
+				first_album = $(".album:first");
+				if (first_album.length !== 0) {
+					first_album.focus();
+				} else {
+					first_photo = $(".photo:first");
+					if (first_photo.length !== 0) {
+						first_photo.focus();
+					}
+				}
 				setTimeout(() => {
 					lychee.footer_show();
 				},
@@ -51,7 +63,19 @@ albums.load = function () {
 		setTimeout(() => {
 			header.setMode('albums');
 			view.albums.init();
-			lychee.animate(lychee.content, 'contentZoomIn')
+			lychee.animate(lychee.content, 'contentZoomIn');
+
+			tabindex.makeFocusable(lychee.content);
+			// Put focus on first element - either album or photo
+			first_album = $(".album:first");
+			if (first_album.length !== 0) {
+				first_album.focus();
+			} else {
+				first_photo = $(".photo:first");
+				if (first_photo.length !== 0) {
+					first_photo.focus();
+				}
+			}
 		}, 300)
 
 	}

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -88,7 +88,7 @@ build.album = function (data, disabled = false) {
 	}
 
 	html += lychee.html`
-			<div class='album ${(disabled ? `disabled` : ``)}' data-id='${data.id}' tabindex='${tabindex.get_next_tab_index()}'>
+			<div class='album ${(disabled ? `disabled` : ``)}' data-id='${data.id}' data-tabindex='${tabindex.get_next_tab_index()}'>
 				  ${build.getAlbumThumb(data, 2)}
 				  ${build.getAlbumThumb(data, 1)}
 				  ${build.getAlbumThumb(data, 0)}
@@ -136,12 +136,12 @@ build.photo = function (data, disabled = false) {
 	let isLivePhoto = (data.livePhotoUrl!=='' && data.livePhotoUrl!==null);
 
 	if (data.thumbUrl === 'uploads/thumb/' && isLivePhoto) {
-		thumbnail = `<span class="thumbimg"><img src='img/live-photo-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+		thumbnail = `<span class="thumbimg"><img src='img/live-photo-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false' data-tabindex='${tabindex.get_next_tab_index()}'></span>`
 	}
 	if (data.thumbUrl === 'uploads/thumb/' && isVideo) {
-		thumbnail = `<span class="thumbimg"><img src='img/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+		thumbnail = `<span class="thumbimg"><img src='img/play-icon.png' alt='Photo thumbnail' data-overlay='false' draggable='false' data-tabindex='${tabindex.get_next_tab_index()}'></span>`
 	} else if (data.thumbUrl === 'uploads/thumb/' && isRaw) {
-		thumbnail = `<span class="thumbimg"><img src='img/placeholder.png' alt='Photo thumbnail' data-overlay='false' draggable='false'></span>`
+		thumbnail = `<span class="thumbimg"><img src='img/placeholder.png' alt='Photo thumbnail' data-overlay='false' draggable='false' data-tabindex='${tabindex.get_next_tab_index()}'></span>`
 	} else if (lychee.layout === '0') {
 
 		if (data.hasOwnProperty('thumb2x')) { // Lychee v4
@@ -155,7 +155,7 @@ build.photo = function (data, disabled = false) {
 		}
 
 		thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}${isLivePhoto ? ' livephoto' : ''}">`;
-		thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+		thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false' >`;
 		thumbnail += `</span>`
 	} else {
 
@@ -165,7 +165,7 @@ build.photo = function (data, disabled = false) {
 			}
 
 			thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}${isLivePhoto ? ' livephoto' : ''}">`;
-			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.small}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.small}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false' >`;
 			thumbnail += `</span>`
 		} else if (data.medium !== '') {
 			if (data.hasOwnProperty('medium2x') && data.medium2x !== '') {
@@ -173,12 +173,12 @@ build.photo = function (data, disabled = false) {
 			}
 
 			thumbnail = `<span class="thumbimg${isVideo ? ' video' : ''}${isLivePhoto ? ' livephoto' : ''}">`;
-			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.medium}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`
+			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.medium}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false' >`
 			thumbnail += `</span>`
 		} else if (!isVideo) {
 			// Fallback for images with no small or medium.
 			thumbnail = `<span class="thumbimg${isLivePhoto ? ' livephoto' : ''}">`;
-			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.url}' alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.url}' alt='Photo thumbnail' data-overlay='false' draggable='false' >`;
 			thumbnail += `</span>`
 		} else {
 			// Fallback for videos with no small (the case of no thumb is
@@ -195,14 +195,14 @@ build.photo = function (data, disabled = false) {
 			}
 
 			thumbnail = `<span class="thumbimg video">`;
-			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false'>`;
+			thumbnail += `<img class='lazyload' src='img/placeholder.png' data-src='${data.thumbUrl}' ` + thumb2x + ` alt='Photo thumbnail' data-overlay='false' draggable='false' >`;
 			thumbnail += `</span>`
 		}
 
 	}
 
 	html += lychee.html`
-			<div class='photo ${(disabled ? `disabled` : ``)}' data-album-id='${data.album}' data-id='${data.id}' tabindex='${tabindex.get_next_tab_index()}'>
+			<div class='photo ${(disabled ? `disabled` : ``)}' data-album-id='${data.album}' data-id='${data.id}' data-tabindex='${tabindex.get_next_tab_index()}'>
 				${thumbnail}
 				<div class='overlay'>
 					<h1 title='$${data.title}'>$${data.title}</h1>
@@ -272,9 +272,9 @@ build.imageview = function (data, visibleControls, autoplay) {
 	let thumb = '';
 
 	if (data.type.indexOf('video') > -1) {
-		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' ${autoplay ? 'autoplay' : ''}><source src='${data.url}'>Your browser does not support the video tag.</video>`
+		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' ${autoplay ? 'autoplay' : ''} data-tabindex='${tabindex.get_next_tab_index()}'><source src='${data.url}'>Your browser does not support the video tag.</video>`
 	} else if (data.type.indexOf('raw') > -1) {
-		html += lychee.html`<img id='image' class='${visibleControls === true ? '' : 'full'}' src='img/placeholder.png' draggable='false' alt='big'>`
+		html += lychee.html`<img id='image' class='${visibleControls === true ? '' : 'full'}' src='img/placeholder.png' draggable='false' alt='big' data-tabindex='${tabindex.get_next_tab_index()}'>`
 	} else {
 		let img = '';
 
@@ -298,10 +298,10 @@ build.imageview = function (data, visibleControls, autoplay) {
 				if (data.hasOwnProperty('medium2x') && data.medium2x !== '') {
 					medium = `srcset='${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w'`;
 				}
-				img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.medium}' ` + medium + `  draggable='false' alt='medium'>`
+				img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.medium}' ` + medium + `  draggable='false' alt='medium' data-tabindex='${tabindex.get_next_tab_index()}'>`
 
 			} else {
-				img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.url}' draggable='false' alt='big'>`
+				img = `<img id='image' class='${visibleControls === true ? '' : 'full'}' src='${data.url}' draggable='false' alt='big' data-tabindex='${tabindex.get_next_tab_index()}'>`
 			}
 		} else {
 
@@ -310,11 +310,11 @@ build.imageview = function (data, visibleControls, autoplay) {
 				let medium_width = medium_dims[0];
 				let medium_height = medium_dims[1];
 				// It's a live photo
-				img = `<div id='livephoto' data-live-photo data-proactively-loads-video='true' data-photo-src='${data.medium}' data-video-src='${data.livePhotoUrl}'  style='width: ${medium_width}px; height: ${medium_height}px'></div>`
+				img = `<div id='livephoto' data-live-photo data-proactively-loads-video='true' data-photo-src='${data.medium}' data-video-src='${data.livePhotoUrl}'  style='width: ${medium_width}px; height: ${medium_height}px' data-tabindex='${tabindex.get_next_tab_index()}'></div>`
 
 			} else {
 				// It's a live photo
-				img = `<div id='livephoto' data-live-photo data-proactively-loads-video='true' data-photo-src='${data.url}' data-video-src='${data.livePhotoUrl}'  style='width: ${data.width}px; height: ${data.height}px'></div>`
+				img = `<div id='livephoto' data-live-photo data-proactively-loads-video='true' data-photo-src='${data.url}' data-video-src='${data.livePhotoUrl}'  style='width: ${data.width}px; height: ${data.height}px' data-tabindex='${tabindex.get_next_tab_index()}'></div>`
 			}
 
 		}

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -272,7 +272,7 @@ build.imageview = function (data, visibleControls, autoplay) {
 	let thumb = '';
 
 	if (data.type.indexOf('video') > -1) {
-		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' ${autoplay ? 'autoplay' : ''} data-tabindex='${tabindex.get_next_tab_index()}'><source src='${data.url}'>Your browser does not support the video tag.</video>`
+		html += lychee.html`<video width="auto" height="auto" id='image' controls class='${visibleControls === true ? '' : 'full'}' autobuffer ${autoplay ? 'autoplay' : ''} data-tabindex='${tabindex.get_next_tab_index()}'><source src='${data.url}'>Your browser does not support the video tag.</video>`
 	} else if (data.type.indexOf('raw') > -1 && data.medium === '') {
 		html += lychee.html`<img id='image' class='${visibleControls === true ? '' : 'full'}' src='img/placeholder.png' draggable='false' alt='big' data-tabindex='${tabindex.get_next_tab_index()}'>`
 	} else {

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -24,7 +24,7 @@ header.bind = function() {
 
 		if ($(this).hasClass('header__title--editable')===false) return false;
 
-		if(lychee.enable_contextmenu_header==false) return false;
+		if(lychee.enable_contextmenu_header===false) return false;
 
 		if (visible.photo()) contextMenu.photoTitle(album.getID(), photo.getID(), e);
 		else                 contextMenu.albumTitle(album.getID(), e)
@@ -176,22 +176,22 @@ header.setMode = function(mode) {
 			tabindex.makeUnfocusable(header.dom('.header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map'));
 
 			if (lychee.public_search) {
-				e = $('.header__search, .header__clear', '.header__toolbar--public');
+				let e = $('.header__search, .header__clear', '.header__toolbar--public');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('.header__search, .header__clear', '.header__toolbar--public');
+				let e = $('.header__search, .header__clear', '.header__toolbar--public');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 
 			// Set icon in Public mode
 			if (lychee.map_display_public) {
-				e = $('.button--map-albums', '.header__toolbar--public');
+				let e = $('.button--map-albums', '.header__toolbar--public');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('.button--map-albums', '.header__toolbar--public')
+				let e = $('.button--map-albums', '.header__toolbar--public')
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
@@ -213,21 +213,21 @@ header.setMode = function(mode) {
 
 			// If map is disabled, we should hide the icon
 			if (lychee.map_display) {
-				e = $('.button--map-albums', '.header__toolbar--albums');
+				let e = $('.button--map-albums', '.header__toolbar--albums');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('.button--map-albums', '.header__toolbar--albums');
+				let e = $('.button--map-albums', '.header__toolbar--albums');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 
 			if(lychee.enable_button_add) {
-				e = $('.button_add', '.header__toolbar--albums');
+				let e = $('.button_add', '.header__toolbar--albums');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('.button_add', '.header__toolbar--albums');
+				let e = $('.button_add', '.header__toolbar--albums');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
@@ -250,32 +250,32 @@ header.setMode = function(mode) {
 			// Hide download button when album empty or we are not allowed to
 			// upload to it and it's not explicitly marked as downloadable.
 			if (!album.json || (album.json.photos === false && album.json.albums && album.json.albums.length === 0) || (!album.isUploadable() && album.json.downloadable === '0')) {
-				e = $('#button_archive');
+				let e = $('#button_archive');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			} else {
-				e = $('#button_archive');
+				let e = $('#button_archive');
 				e.show();
 				tabindex.makeFocusable(e);
 			}
 
 			if (album.json && album.json.hasOwnProperty('share_button_visible') && album.json.share_button_visible !== '1') {
-				e = $('#button_share_album');
+				let e = $('#button_share_album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			} else {
-				e = $('#button_share_album');
+				let e = $('#button_share_album');
 				e.show();
 				tabindex.makeFocusable(e);
 			}
 
 			// If map is disabled, we should hide the icon
 			if (lychee.publicMode===true ? lychee.map_display_public : lychee.map_display) {
-				e = $('#button_map_album');
+				let e = $('#button_map_album');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('#button_map_album');
+				let e = $('#button_map_album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
@@ -304,37 +304,37 @@ header.setMode = function(mode) {
 
 			// Remove buttons if needed
 			if(!lychee.enable_button_visibility) {
-				e = $('#button_visibility_album', '.header__toolbar--album');
+				let e = $('#button_visibility_album', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_share) {
-				e = $('#button_share_album', '.header__toolbar--album');
+				let e = $('#button_share_album', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_archive) {
-				e = $('#button_archive', '.header__toolbar--album');
+				let e = $('#button_archive', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_move) {
-				e = $('#button_move_album', '.header__toolbar--album');
+				let e = $('#button_move_album', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_trash) {
-				e = $('#button_trash_album', '.header__toolbar--album');
+				let e = $('#button_trash_album', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_fullscreen) {
-				e = $('#button_fs_album_enter', '.header__toolbar--album');
+				let e = $('#button_fs_album_enter', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_add) {
-				e = $('.button_add', '.header__toolbar--album');
+				let e = $('.button_add', '.header__toolbar--album');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
@@ -351,31 +351,31 @@ header.setMode = function(mode) {
 			tabindex.makeUnfocusable(header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map'));
 			// If map is disabled, we should hide the icon
 			if (lychee.publicMode===true ? lychee.map_display_public : lychee.map_display) {
-				e = $('#button_map');
+				let e = $('#button_map');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('#button_map');
+				let e = $('#button_map');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 
 			if (album.isUploadable()) {
-				e = $('#button_trash, #button_move, #button_visibility, #button_star');
+				let e = $('#button_trash, #button_move, #button_visibility, #button_star');
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				e = $('#button_trash, #button_move, #button_visibility, #button_star');
+				let e = $('#button_trash, #button_move, #button_visibility, #button_star');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 
 			if (photo.json && photo.json.hasOwnProperty('share_button_visible') && photo.json.share_button_visible !== '1') {
-				e = $('#button_share');
+				let e = $('#button_share');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			} else {
-				e = $('#button_share');
+				let e = $('#button_share');
 				e.show();
 				tabindex.makeFocusable(e);
 			}
@@ -387,44 +387,44 @@ header.setMode = function(mode) {
 				(photo.json.hasOwnProperty('downloadable') ? photo.json.downloadable === '1' :
 				album.json && album.json.downloadable && album.json.downloadable === '1')) &&
 				!(photo.json.url && photo.json.url !== '')) {
-				e = $('#button_more');
+				let e = $('#button_more');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 
 			// Remove buttons if needed
 			if(!lychee.enable_button_visibility) {
-				e = $('#button_visibility', '.header__toolbar--photo');
+				let e = $('#button_visibility', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_share) {
-				e = $('#button_share', '.header__toolbar--photo');
+				let e = $('#button_share', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_move) {
-				e = $('#button_move', '.header__toolbar--photo');
+				let e = $('#button_move', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_trash) {
-				e = $('#button_trash', '.header__toolbar--photo');
+				let e = $('#button_trash', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_fullscreen) {
-				e = $('#button_fs_enter', '.header__toolbar--photo');
+				let e = $('#button_fs_enter', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_more) {
-				e = $('#button_more', '.header__toolbar--photo');
+				let e = $('#button_more', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
 			if(!lychee.enable_button_rotate) {
-				e = $('#button_rotate_cwise', '.header__toolbar--photo');
+				let e = $('#button_rotate_cwise', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -24,6 +24,8 @@ header.bind = function() {
 
 		if ($(this).hasClass('header__title--editable')===false) return false;
 
+		if(lychee.enable_contextmenu_header==false) return false;
+
 		if (visible.photo()) contextMenu.photoTitle(album.getID(), photo.getID(), e);
 		else                 contextMenu.albumTitle(album.getID(), e)
 
@@ -425,7 +427,7 @@ header.setMode = function(mode) {
 				e = $('#button_rotate_cwise', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
-				
+
 				e = $('#button_rotate_ccwise', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -228,8 +228,7 @@ header.setMode = function(mode) {
 				tabindex.makeFocusable(e);
 			} else {
 				let e = $('.button_add', '.header__toolbar--albums');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 
 
@@ -305,38 +304,31 @@ header.setMode = function(mode) {
 			// Remove buttons if needed
 			if(!lychee.enable_button_visibility) {
 				let e = $('#button_visibility_album', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_share) {
 				let e = $('#button_share_album', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_archive) {
 				let e = $('#button_archive', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_move) {
 				let e = $('#button_move_album', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_trash) {
 				let e = $('#button_trash_album', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_fullscreen) {
 				let e = $('#button_fs_album_enter', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_add) {
 				let e = $('.button_add', '.header__toolbar--album');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 
 			return true;
@@ -395,42 +387,34 @@ header.setMode = function(mode) {
 			// Remove buttons if needed
 			if(!lychee.enable_button_visibility) {
 				let e = $('#button_visibility', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_share) {
 				let e = $('#button_share', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_move) {
 				let e = $('#button_move', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_trash) {
 				let e = $('#button_trash', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_fullscreen) {
 				let e = $('#button_fs_enter', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_more) {
 				let e = $('#button_more', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			if(!lychee.enable_button_rotate) {
 				let e = $('#button_rotate_cwise', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 
 				e = $('#button_rotate_ccwise', '.header__toolbar--photo');
-				e.hide();
-				tabindex.makeUnfocusable(e);
+				e.remove();
 			}
 			return true;
 		case 'map':

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -421,7 +421,15 @@ header.setMode = function(mode) {
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
-
+			if(!lychee.enable_button_rotate) {
+				e = $('#button_rotate_cwise', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+				
+				e = $('#button_rotate_ccwise', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
 			return true;
 		case 'map':
 

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -192,6 +192,10 @@ header.setMode = function(mode) {
 				tabindex.makeUnfocusable(e);
 			}
 
+			// Set focus on login button
+			if(lychee.active_focus_on_page_load) {
+				$('#button_signin').focus();
+			}
 			return true;
 
 		case 'albums':
@@ -213,6 +217,17 @@ header.setMode = function(mode) {
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}
+
+			if(lychee.enable_button_add) {
+				e = $('.button_add', '.header__toolbar--albums');
+				e.show();
+				tabindex.makeFocusable(e);
+			} else {
+				e = $('.button_add', '.header__toolbar--albums');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+
 
 			return true;
 
@@ -283,7 +298,42 @@ header.setMode = function(mode) {
 				}
 			}
 
-
+			// Remove buttons if needed
+			if(!lychee.enable_button_visibility) {
+				e = $('#button_visibility_album', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_share) {
+				e = $('#button_share_album', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_archive) {
+				e = $('#button_archive', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_move) {
+				e = $('#button_move_album', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_trash) {
+				e = $('#button_trash_album', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_fullscreen) {
+				e = $('#button_fs_album_enter', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_add) {
+				e = $('.button_add', '.header__toolbar--album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
 
 			return true;
 
@@ -334,6 +384,38 @@ header.setMode = function(mode) {
 				album.json && album.json.downloadable && album.json.downloadable === '1')) &&
 				!(photo.json.url && photo.json.url !== '')) {
 				e = $('#button_more');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+
+			// Remove buttons if needed
+			if(!lychee.enable_button_visibility) {
+				e = $('#button_visibility', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_share) {
+				e = $('#button_share', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_move) {
+				e = $('#button_move', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_trash) {
+				e = $('#button_trash', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_fullscreen) {
+				e = $('#button_fs_enter', '.header__toolbar--photo');
+				e.hide();
+				tabindex.makeUnfocusable(e);
+			}
+			if(!lychee.enable_button_more) {
+				e = $('#button_more', '.header__toolbar--photo');
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -110,6 +110,8 @@ header.show = function() {
 	lychee.imageview.removeClass('full');
 	header.dom().removeClass('header--hidden');
 
+	tabindex.restoreSettings(header.dom());
+
 	photo.updateSizeLivePhotoDuringAnimation();
 
 	return true
@@ -127,6 +129,9 @@ header.hideIfLivePhotoNotPlaying = function() {
 header.hide = function() {
 
 	if (visible.photo() && !visible.sidebar() && !visible.contextMenu() && basicModal.visible()===false) {
+
+		tabindex.saveSettings(header.dom());
+		tabindex.makeUnfocusable(header.dom());
 
 		lychee.imageview.addClass('full');
 		header.dom().addClass('header--hidden');
@@ -163,17 +168,28 @@ header.setMode = function(mode) {
 			header.dom().removeClass('header--view');
 			header.dom('.header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--public').addClass('header__toolbar--visible');
+			tabindex.makeFocusable(header.dom('.header__toolbar--public'));
+			tabindex.makeUnfocusable(header.dom('.header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map'));
+
 			if (lychee.public_search) {
-				$('.header__search, .header__clear', '.header__toolbar--public').show()
+				e = $('.header__search, .header__clear', '.header__toolbar--public');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('.header__search, .header__clear', '.header__toolbar--public').hide()
+				e = $('.header__search, .header__clear', '.header__toolbar--public');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			// Set icon in Public mode
 			if (lychee.map_display_public) {
-				$('.button--map-albums', '.header__toolbar--public').show();
+				e = $('.button--map-albums', '.header__toolbar--public');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('.button--map-albums', '.header__toolbar--public').hide();
+				e = $('.button--map-albums', '.header__toolbar--public')
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			return true;
@@ -184,12 +200,18 @@ header.setMode = function(mode) {
 			header.dom('.header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--albums').addClass('header__toolbar--visible');
 
+			tabindex.makeFocusable(header.dom('.header__toolbar--albums'));
+			tabindex.makeUnfocusable(header.dom('.header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map'));
+
 			// If map is disabled, we should hide the icon
 			if (lychee.map_display) {
-				$('.button--map-albums', '.header__toolbar--albums').show();
-
+				e = $('.button--map-albums', '.header__toolbar--albums');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('.button--map-albums', '.header__toolbar--albums').hide();
+				e = $('.button--map-albums', '.header__toolbar--albums');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			return true;
@@ -202,39 +224,62 @@ header.setMode = function(mode) {
 			header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--album').addClass('header__toolbar--visible');
 
+			tabindex.makeFocusable(header.dom('.header__toolbar--album'));
+			tabindex.makeUnfocusable(header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map'));
+
+
 			// Hide download button when album empty or we are not allowed to
 			// upload to it and it's not explicitly marked as downloadable.
 			if (!album.json || (album.json.photos === false && album.json.albums && album.json.albums.length === 0) || (!album.isUploadable() && album.json.downloadable === '0')) {
-				$('#button_archive').hide();
+				e = $('#button_archive');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			} else {
-				$('#button_archive').show();
+				e = $('#button_archive');
+				e.show();
+				tabindex.makeFocusable(e);
 			}
 
 			if (album.json && album.json.hasOwnProperty('share_button_visible') && album.json.share_button_visible !== '1') {
-				$('#button_share_album').hide();
+				e = $('#button_share_album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			} else {
-				$('#button_share_album').show();
+				e = $('#button_share_album');
+				e.show();
+				tabindex.makeFocusable(e);
 			}
 
 			// If map is disabled, we should hide the icon
 			if (lychee.publicMode===true ? lychee.map_display_public : lychee.map_display) {
-				$('#button_map_album').show();
+				e = $('#button_map_album');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('#button_map_album').hide();
+				e = $('#button_map_album');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			if (albumID==='s' || albumID==='f' || albumID==='r') {
 				$('#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album').hide();
-				$('.button_add, .header__divider', '.header__toolbar--album').show()
+				$('.button_add, .header__divider', '.header__toolbar--album').show();
+				tabindex.makeFocusable($('.button_add, .header__divider', '.header__toolbar--album').show());
+				tabindex.makeUnfocusable($('#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album'));
 			} else if (albumID==='0') {
 				$('#button_info_album, #button_visibility_album, #button_move_album').hide();
-				$('#button_trash_album, .button_add, .header__divider', '.header__toolbar--album').show()
+				$('#button_trash_album, .button_add, .header__divider', '.header__toolbar--album').show();
+				tabindex.makeFocusable($('#button_trash_album, .button_add, .header__divider', '.header__toolbar--album'));
+				tabindex.makeUnfocusable($('#button_info_album, #button_visibility_album, #button_move_album'));
 			} else {
 				$('#button_info_album, #button_visibility_album').show();
+				tabindex.makeFocusable($('#button_info_album, #button_visibility_album'));
 				if (album.isUploadable()) {
-					$('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album').show()
+					$('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album').show();
+					tabindex.makeFocusable($('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album'));
 				} else {
-					$('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album').hide()
+					$('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album').hide();
+					tabindex.makeUnfocusable($('#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider', '.header__toolbar--album'));
 				}
 			}
 
@@ -248,32 +293,49 @@ header.setMode = function(mode) {
 			header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--photo').addClass('header__toolbar--visible');
 
+			tabindex.makeFocusable(header.dom('.header__toolbar--photo'));
+			tabindex.makeUnfocusable(header.dom('.header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map'));
 			// If map is disabled, we should hide the icon
 			if (lychee.publicMode===true ? lychee.map_display_public : lychee.map_display) {
-				$('#button_map').show();
+				e = $('#button_map');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('#button_map').hide();
+				e = $('#button_map');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			if (album.isUploadable()) {
-				$('#button_trash, #button_move, #button_visibility, #button_star').show()
+				e = $('#button_trash, #button_move, #button_visibility, #button_star');
+				e.show();
+				tabindex.makeFocusable(e);
 			} else {
-				$('#button_trash, #button_move, #button_visibility, #button_star').hide();
+				e = $('#button_trash, #button_move, #button_visibility, #button_star');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			if (photo.json && photo.json.hasOwnProperty('share_button_visible') && photo.json.share_button_visible !== '1') {
-				$('#button_share').hide();
+				e = $('#button_share');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			} else {
-				$('#button_share').show();
+				e = $('#button_share');
+				e.show();
+				tabindex.makeFocusable(e);
 			}
 
 			// Hide More menu if empty (see contextMenu.photoMore)
 			$('#button_more').show();
+			tabindex.makeFocusable($('#button_more'));
 			if (!(album.isUploadable() ||
 				(photo.json.hasOwnProperty('downloadable') ? photo.json.downloadable === '1' :
 				album.json && album.json.downloadable && album.json.downloadable === '1')) &&
 				!(photo.json.url && photo.json.url !== '')) {
-				$('#button_more').hide();
+				e = $('#button_more');
+				e.hide();
+				tabindex.makeUnfocusable(e);
 			}
 
 			return true;
@@ -283,6 +345,8 @@ header.setMode = function(mode) {
 			header.dom('.header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo').removeClass('header__toolbar--visible');
 			header.dom('.header__toolbar--map').addClass('header__toolbar--visible');
 
+			tabindex.makeFocusable(header.dom('.header__toolbar--map'));
+			tabindex.makeUnfocusable(header.dom('.header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo'));
 			return true;
 
 	}

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -41,14 +41,14 @@ $(document).ready(function() {
 			lychee.loginDialog(); return false
 		})
 		.bind([ 'left' ], function() {
-			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
+			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length === 0 ))) {
 				$('#imageview a#previous').click();
 				return false;
 			}
 			return true;
 		})
 		.bind([ 'right' ], function() {
-			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
+			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length === 0 ))) {
 				 $('#imageview a#next').click();
 				 return false;
 			}
@@ -102,7 +102,7 @@ $(document).ready(function() {
 
 		Mousetrap.bind([ 'play_pause' ], function() {
 			// If it's a video, we toggle play/pause
-			video = $("video");
+			let video = $("video");
 
 			if (video.length !== 0) {
 				if(video[0].paused) {
@@ -122,7 +122,7 @@ $(document).ready(function() {
         basicModal.action();
         return false;
       }
-		} else if (visible.photo() && !lychee.header_auto_hide && ($('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
+		} else if (visible.photo() && !lychee.header_auto_hide && ($('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length === 0 ))) {
 			if (visible.header()) {
 				header.hide();
 			} else {

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -4,11 +4,8 @@
 
 $(document).ready(function() {
 
-	// Event Name
-	let eventName = lychee.getEventName();
-
 	// set CSRF protection (Laravel)
-    csrf.bind();
+  csrf.bind();
 
 	// Set API error handler
 	api.onError = lychee.error;
@@ -142,41 +139,44 @@ $(document).ready(function() {
 		else if (visible.album())													 lychee.goto(album.getParent());
 		else if (visible.albums() && search.hash !== null) search.reset();
 		else if (visible.mapview())                        mapview.close();
+		else if (visible.albums() && lychee.enable_close_tab_on_esc) {
+			window.open("", "_self").close();
+		}
 		return false;
 	});
 
-	if (eventName==='touchend') {
 
-		$(document)
 
-			// Fullscreen on mobile
-			.on('touchend', '#imageview #image', function(e) {
+	$(document)
 
-				// prevent triggering event 'mousemove'
-				e.preventDefault();
+		// Fullscreen on mobile
+		.on('touchend', '#imageview #image', function(e) {
 
-				if ((typeof swipe.obj === 'undefined') || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
-					// Toggle header only if we're not moving to next/previous photo;
-					// In this case, swipe.preventNextHeaderToggle is set to true
-					if((typeof swipe.preventNextHeaderToggle === 'undefined') || (!swipe.preventNextHeaderToggle)) {
-						if (visible.header()) {
-							header.hide(e);
-						} else {
-						  header.show();
-						}
+			// prevent triggering event 'mousemove'
+			e.preventDefault();
+
+			if ((typeof swipe.obj === 'undefined') || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
+				// Toggle header only if we're not moving to next/previous photo;
+				// In this case, swipe.preventNextHeaderToggle is set to true
+				if((typeof swipe.preventNextHeaderToggle === 'undefined') || (!swipe.preventNextHeaderToggle)) {
+					if (visible.header()) {
+						header.hide(e);
+					} else {
+					  header.show();
 					}
-
-					// For next 'touchend', behave again as normal and toggle header
-					swipe.preventNextHeaderToggle = false;
 				}
-			});
-		$('#imageview')
-			// Swipe on mobile
-			.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto')) })
-			.swipe().on('swipeMove',  function(e) { if (visible.photo()) swipe.move(e.swipe) })
-			.swipe().on('swipeEnd',   function(e) { if (visible.photo()) swipe.stop(e.swipe, photo.previous, photo.next) })
 
-	}
+				// For next 'touchend', behave again as normal and toggle header
+				swipe.preventNextHeaderToggle = false;
+			}
+		});
+	$('#imageview')
+		// Swipe on mobile
+		.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto')) })
+		.swipe().on('swipeMove',  function(e) { if (visible.photo()) swipe.move(e.swipe) })
+		.swipe().on('swipeEnd',   function(e) { if (visible.photo()) swipe.stop(e.swipe, photo.previous, photo.next) })
+
+
 
 	// Document
 	$(document)

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -4,6 +4,9 @@
 
 $(document).ready(function() {
 
+  // Event Name
+	let eventName = lychee.getEventName();
+
 	// set CSRF protection (Laravel)
   csrf.bind();
 
@@ -20,9 +23,9 @@ $(document).ready(function() {
 
 	// Image View
 	lychee.imageview
-		.on('click', '.arrow_wrapper--previous', photo.previous)
-		.on('click', '.arrow_wrapper--next',     photo.next)
-		.on('click', 'img, #livephoto', photo.update_display_overlay);
+		.on(eventName, '.arrow_wrapper--previous', photo.previous)
+		.on(eventName, '.arrow_wrapper--next',     photo.next)
+		.on(eventName, 'img, #livephoto', photo.update_display_overlay);
 
 	// Keyboard
 
@@ -112,8 +115,13 @@ $(document).ready(function() {
 
 	Mousetrap.bindGlobal('enter', function() {
 		if (basicModal.visible()===true) {
-			basicModal.action();
-			return false;
+
+      // check if any of the input fields is focussed
+      // apply action, other do nothing
+      if($('.signIn > input').is(':focus')) {
+        basicModal.action();
+        return false;
+      }
 		} else if (visible.photo() && !lychee.header_auto_hide && ($('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
 			if (visible.header()) {
 				header.hide();
@@ -122,7 +130,10 @@ $(document).ready(function() {
 			}
 			return false;
 		}
-		return true;
+    $(':focus').each(function() {
+      $(this).click();
+    });
+		return false;
 	});
 
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -28,29 +28,31 @@ $(document).ready(function() {
 		.on('click', 'img, #livephoto', photo.update_display_overlay);
 
 	// Keyboard
+
+	Mousetrap.addKeycodes({
+		18  : 'ContextMenu',
+		179	: 'play_pause',
+		227	: 'rewind',
+		228	: 'forward'
+	});
+
 	Mousetrap
 		.bind([ 'l' ], function() {
 			lychee.loginDialog(); return false
 		})
 		.bind([ 'left' ], function() {
-			if (visible.photo()) {
+			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
 				$('#imageview a#previous').click();
 				return false;
-			} else {
-				tab_idx_to_select = tabindex.get_left_tab_index();
-				$('[tabindex=' + tab_idx_to_select + ']').focus();
-				return false;
 			}
+			return true;
 		})
 		.bind([ 'right' ], function() {
-			if (visible.photo()) {
+			if (visible.photo() && (!visible.header() || $('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
 				 $('#imageview a#next').click();
 				 return false;
-			} else {
-				 tab_idx_to_select = tabindex.get_right_tab_index();
-				 $('[tabindex=' + tab_idx_to_select + ']').focus();
-				 return false;
 			}
+			return true;
 		})
 		.bind([ 'u' ], function() {
 			if (!visible.photo() && album.isUploadable()) { $('#upload_files').click(); return false }
@@ -77,7 +79,7 @@ $(document).ready(function() {
 		.bind([ 't' ], function() {
 			if (visible.photo() && album.isUploadable()) { photo.editTags([photo.getID()]); return false }
 		})
-		.bind([ 'i' ], function() {
+		.bind([ 'i' , 'ContextMenu'], function() {
 			if (!visible.multiselect()) { sidebar.toggle(); return false }
 		})
 		.bind([ 'command+backspace', 'ctrl+backspace' ], function() {
@@ -97,9 +99,7 @@ $(document).ready(function() {
 			if (visible.album() || visible.photo()) { lychee.fullscreenToggle(); return false }
 		});
 
-		Mousetrap.addKeycodes({
-    	179	: 'play_pause'
-		});
+
 		Mousetrap.bind([ 'play_pause' ], function() {
 			// If it's a video, we toggle play/pause
 			video = $("video");
@@ -116,27 +116,33 @@ $(document).ready(function() {
 	Mousetrap.bindGlobal('enter', function() {
 		if (basicModal.visible()===true) {
 			basicModal.action();
-		} else {
-			focussed_element = $(':focus');
-			// focus is on an element
-			if (focussed_element.length !== 0) {
-				// trigger a click
-				//focussed_element.click();
+			return false;
+		} else if (visible.photo() && !lychee.header_auto_hide && ($('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length == 0 ))) {
+			if (visible.header()) {
+				header.hide();
+			} else {
+				header.show();
 			}
+			return false;
 		}
-
+		return true;
 	});
 
+
+	// Prevent 'esc keyup' event to trigger 'go back in history'
+	// and 'alt keyup' to show a webapp context menu for Fire TV
+	Mousetrap.bindGlobal([ 'esc', 'ContextMenu' ], function() { return false;	}, 'keyup');
+
 	Mousetrap.bindGlobal([ 'esc', 'command+up' ], function() {
-		/*if (basicModal.visible()===true)                                             basicModal.cancel();
-		else if (visible.leftMenu())												 leftMenu.close();
-		else if (visible.contextMenu())                                              contextMenu.close();
-		else if (visible.photo())                                                    lychee.goto(album.getID());
-		else if (visible.album() && !album.json.parent_id)                           lychee.goto();
+		if (basicModal.visible()===true)                   basicModal.cancel();
+		else if (visible.leftMenu())											 leftMenu.close();
+		else if (visible.contextMenu())                    contextMenu.close();
+		else if (visible.photo())                          lychee.goto(album.getID());
+		else if (visible.album() && !album.json.parent_id) lychee.goto();
 		else if (visible.album())													 lychee.goto(album.getParent());
 		else if (visible.albums() && search.hash !== null) search.reset();
-		else if (visible.mapview())                                                  mapview.close();
-		return false*/
+		else if (visible.mapview())                        mapview.close();
+		return false;
 	});
 
 	if (eventName==='touchend') {
@@ -150,7 +156,7 @@ $(document).ready(function() {
 				e.preventDefault();
 
 				if ((typeof swipe.obj === 'undefined') || (Math.abs(swipe.offsetX)<=5 && Math.abs(swipe.offsetY)<=5)) {
-					// Toogle header only if we're not moving to next/previous photo;
+					// Toggle header only if we're not moving to next/previous photo;
 					// In this case, swipe.preventNextHeaderToggle is set to true
 					if((typeof swipe.preventNextHeaderToggle === 'undefined') || (!swipe.preventNextHeaderToggle)) {
 						if (visible.header()) {
@@ -160,7 +166,7 @@ $(document).ready(function() {
 						}
 					}
 
-					// For next 'touchend', behave again as normal and toogle header
+					// For next 'touchend', behave again as normal and toggle header
 					swipe.preventNextHeaderToggle = false;
 				}
 			});
@@ -245,6 +251,6 @@ $(document).ready(function() {
 	});
 
 	// Init
-	lychee.init()
+	lychee.init();
 
 });

--- a/scripts/main/leftMenu.js
+++ b/scripts/main/leftMenu.js
@@ -17,24 +17,24 @@ leftMenu.dom = function(selector) {
 
 leftMenu.build = function () {
 	let html = lychee.html`
-		<a id="text_settings_close" class="closetxt">${ lychee.locale['CLOSE'] }</a>
-		<a id="button_settings_close" class="closebtn" >&times;</a>
-		<a class="linkMenu" id="button_settings_open"><svg class="iconic"><use xlink:href="#cog"></use></svg>${ lychee.locale['SETTINGS'] }</a>`;
+		<a id="text_settings_close" class="closetxt" data-tabindex="-1">${ lychee.locale['CLOSE'] }</a>
+		<a id="button_settings_close" class="closebtn" data-tabindex="20">&times;</a>
+		<a class="linkMenu" id="button_settings_open" data-tabindex="-1"><svg class="iconic"><use xlink:href="#cog"></use></svg>${ lychee.locale['SETTINGS'] }</a>`;
 	if (lychee.api_V2)
 	{
 		html += lychee.html`
-		<a class="linkMenu" id="button_users">${    build.iconic('person') }${             lychee.locale['USERS'] } </a>
-		<a class="linkMenu" id="button_sharing">${  build.iconic('cloud') }${              lychee.locale['SHARING'] }</a>`
+		<a class="linkMenu" id="button_users" data-tabindex="-1">${    build.iconic('person') }${             lychee.locale['USERS'] } </a>
+		<a class="linkMenu" id="button_sharing" data-tabindex="-1">${  build.iconic('cloud') }${              lychee.locale['SHARING'] }</a>`
 	}
 	html += lychee.html`
-		<a class="linkMenu" id="button_logs">${         build.iconic('align-left') }${     lychee.locale['LOGS'] }</a>
-		<a class="linkMenu" id="button_diagnostics">${  build.iconic('wrench') }${         lychee.locale['DIAGNOSTICS'] }</a>
-		<a class="linkMenu" id="button_about">${        build.iconic('info') }${           lychee.locale['ABOUT_LYCHEE'] }</a>
-		<a class="linkMenu" id="button_signout">${      build.iconic('account-logout') }${ lychee.locale['SIGN_OUT'] }</a>`;
+		<a class="linkMenu" id="button_logs" data-tabindex="-1">${         build.iconic('align-left') }${     lychee.locale['LOGS'] }</a>
+		<a class="linkMenu" id="button_diagnostics" data-tabindex="-1">${  build.iconic('wrench') }${         lychee.locale['DIAGNOSTICS'] }</a>
+		<a class="linkMenu" id="button_about" data-tabindex="-1">${        build.iconic('info') }${           lychee.locale['ABOUT_LYCHEE'] }</a>
+		<a class="linkMenu" id="button_signout" data-tabindex="21">${      build.iconic('account-logout') }${ lychee.locale['SIGN_OUT'] }</a>`;
 	if (lychee.api_V2 && lychee.update_available)
 	{
 		html += lychee.html`
-		<a class="linkMenu" id="button_update">${ build.iconic('timer')}${ lychee.locale['UPDATE_AVAILABLE']}</a>
+		<a class="linkMenu" id="button_update"  data-tabindex="-1">${ build.iconic('timer')}${ lychee.locale['UPDATE_AVAILABLE']}</a>
 		`
 	}
 	leftMenu._dom.html(html)
@@ -48,6 +48,12 @@ leftMenu.open = function () {
 	header.dom('.header__title').addClass('leftMenu__open');
 	loadingBar.dom().addClass('leftMenu__open');
 
+	// Make background unfocusable
+	tabindex.makeUnfocusable(header.dom());
+	tabindex.makeUnfocusable(lychee.content);
+	tabindex.makeFocusable(leftMenu._dom);
+	$('#button_signout').focus();
+
 	multiselect.unbind();
 };
 
@@ -59,6 +65,10 @@ leftMenu.close = function () {
 	$('.content').removeClass('leftMenu__open');
 	header.dom('.header__title').removeClass('leftMenu__open');
 	loadingBar.dom().removeClass('leftMenu__open');
+
+	tabindex.makeFocusable(header.dom());
+	tabindex.makeFocusable(lychee.content);
+	tabindex.makeUnfocusable(leftMenu._dom);
 
 	multiselect.bind();
 	lychee.load();

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -208,22 +208,22 @@ lychee.init = function() {
             lychee.share_button_visible = (data.config.share_button_visible && data.config.share_button_visible === '1') || false;
             lychee.delete_imported = (data.config.delete_imported && data.config.delete_imported === '1');
 
-            lychee.header_auto_hide = data.config_device.header_auto_hide || true;
-            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load || false;
-            lychee.enable_button_visibility = data.config_device.enable_button_visibility || true;
-            lychee.enable_button_share = data.config_device.enable_button_share || true;
-            lychee.enable_button_archive = data.config_device.enable_button_archive || true;
-            lychee.enable_button_move = data.config_device.enable_button_move || true;
-            lychee.enable_button_trash = data.config_device.enable_button_trash || true;
-            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen || true;
-            lychee.enable_button_download = data.config_device.enable_button_download || true;
-            lychee.enable_button_add = data.config_device.enable_button_add || true;
-            lychee.enable_button_more = data.config_device.enable_button_more || true;
-            lychee.enable_button_rotate = data.config_device.enable_button_rotate || true;
-            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc || false;
-            lychee.enable_tabindex = data.config_device.enable_tabindex || false;
-            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
-            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
+            lychee.header_auto_hide = data.config_device.header_auto_hide;
+            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load;
+            lychee.enable_button_visibility = data.config_device.enable_button_visibility;
+            lychee.enable_button_share = data.config_device.enable_button_share;
+            lychee.enable_button_archive = data.config_device.enable_button_archive;
+            lychee.enable_button_move = data.config_device.enable_button_move;
+            lychee.enable_button_trash = data.config_device.enable_button_trash;
+            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen;
+            lychee.enable_button_download = data.config_device.enable_button_download;
+            lychee.enable_button_add = data.config_device.enable_button_add;
+            lychee.enable_button_more = data.config_device.enable_button_more;
+            lychee.enable_button_rotate = data.config_device.enable_button_rotate;
+            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc;
+            lychee.enable_tabindex = data.config_device.enable_tabindex;
+            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header;
+            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview;
             lychee.device_type = data.config_device.device_type || 'desktop'; // we set default as Desktop
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
@@ -266,22 +266,22 @@ lychee.init = function() {
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
 
-            lychee.header_auto_hide = data.config_device.header_auto_hide || true;
-            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load || false;
-            lychee.enable_button_visibility = data.config_device.enable_button_visibility || true;
-            lychee.enable_button_share = data.config_device.enable_button_share || true;
-            lychee.enable_button_archive = data.config_device.enable_button_archive || true;
-            lychee.enable_button_move = data.config_device.enable_button_move || true;
-            lychee.enable_button_trash = data.config_device.enable_button_trash || true;
-            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen || true;
-            lychee.enable_button_download = data.config_device.enable_button_download || true;
-            lychee.enable_button_add = data.config_device.enable_button_add || true;
-            lychee.enable_button_more = data.config_device.enable_button_more || true;
-            lychee.enable_button_rotate = data.config_device.enable_button_rotate || true;
-            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc || false;
-            lychee.enable_tabindex = data.config_device.enable_tabindex || false;
-            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
-            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
+            lychee.header_auto_hide = data.config_device.header_auto_hide;
+            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load;
+            lychee.enable_button_visibility = data.config_device.enable_button_visibility;
+            lychee.enable_button_share = data.config_device.enable_button_share;
+            lychee.enable_button_archive = data.config_device.enable_button_archive;
+            lychee.enable_button_move = data.config_device.enable_button_move;
+            lychee.enable_button_trash = data.config_device.enable_button_trash;
+            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen;
+            lychee.enable_button_download = data.config_device.enable_button_download;
+            lychee.enable_button_add = data.config_device.enable_button_add;
+            lychee.enable_button_more = data.config_device.enable_button_more;
+            lychee.enable_button_rotate = data.config_device.enable_button_rotate;
+            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc;
+            lychee.enable_tabindex = data.config_device.enable_tabindex;
+            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header;
+            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview;
             lychee.device_type = data.config_device.device_type || 'desktop'; // we set default as Desktop
 
             // console.log(lychee.full_photo);

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -55,6 +55,7 @@ let lychee = {
 	enable_button_rotate : true,
 	enable_close_tab_on_esc : false,
 	enable_tabindex : false,
+	enable_contextmenu_header : true,
 	device_type: 'Desktop',
 
 	checkForUpdates: '1',
@@ -219,7 +220,8 @@ lychee.init = function() {
 						lychee.enable_button_rotate        = data.config.enable_button_rotate;
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
-						lychee.device_type                  = data.config.device_type;
+						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
+						lychee.device_type                 = data.config.device_type;
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
 
@@ -275,6 +277,7 @@ lychee.init = function() {
 						lychee.enable_button_rotate        = data.config.enable_button_rotate;
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
+						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
 						lychee.device_type                 = data.config.device_type;
 
             // console.log(lychee.full_photo);

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -52,8 +52,10 @@ let lychee = {
 	enable_button_download : true,
 	enable_button_add : true,
 	enable_button_more : true,
+	enable_button_rotate : true,
 	enable_close_tab_on_esc : false,
 	enable_tabindex : false,
+	device_type: 'Desktop',
 
 	checkForUpdates: '1',
 	update_json: 0,
@@ -214,8 +216,10 @@ lychee.init = function() {
 						lychee.enable_button_download      = data.config.enable_button_download;
 						lychee.enable_button_add           = data.config.enable_button_add;
 						lychee.enable_button_more          = data.config.enable_button_more;
+						lychee.enable_button_rotate        = data.config.enable_button_rotate;
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
+						lychee.device_type                  = data.config.device_type;
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
 
@@ -268,8 +272,10 @@ lychee.init = function() {
 						lychee.enable_button_download      = data.config.enable_button_download;
 						lychee.enable_button_add           = data.config.enable_button_add;
 						lychee.enable_button_more          = data.config.enable_button_more;
+						lychee.enable_button_rotate        = data.config.enable_button_rotate;
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
+						lychee.device_type                 = data.config.device_type;
 
             // console.log(lychee.full_photo);
             lychee.setMode('public');
@@ -725,9 +731,10 @@ lychee.loadDropbox = function(callback) {
 
 lychee.getEventName = function() {
 
-    let touchendSupport = (/Android|iPhone|iPad|iPod/i).test(navigator.userAgent || navigator.vendor || window.opera) && ('ontouchend' in document.documentElement);
-    return (touchendSupport === true ? 'touchend' : 'click')
-
+		if (lychee.device_type=='Mobile') {
+			return 'touchend';
+		}
+		return 'click';
 };
 
 lychee.escapeHTML = function(html = '') {

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -56,6 +56,7 @@ let lychee = {
 	enable_close_tab_on_esc : false,
 	enable_tabindex : false,
 	enable_contextmenu_header : true,
+	hide_content_during_imageview : false,
 	device_type: 'Desktop',
 
 	checkForUpdates: '1',
@@ -221,6 +222,7 @@ lychee.init = function() {
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
 						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
+						lychee.hide_content_during_imgview = data.config.hide_content_during_imgview;
 						lychee.device_type                 = data.config.device_type;
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
@@ -278,6 +280,7 @@ lychee.init = function() {
 						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
 						lychee.enable_tabindex             = data.config.enable_tabindex;
 						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
+						lychee.hide_content_during_imgview = data.config.hide_content_during_imgview;
 						lychee.device_type                 = data.config.device_type;
 
             // console.log(lychee.full_photo);
@@ -471,6 +474,10 @@ lychee.load = function(autoplay = true) {
 
 						// Make thumbnails unfocusable and store which element had focus
 						tabindex.makeUnfocusable(lychee.content, true);
+
+						// hide contentview if requested
+						if(lychee.hide_content_during_imgview) lychee.content.hide();
+
             lychee.footer_hide();
         }
 
@@ -514,6 +521,7 @@ lychee.load = function(autoplay = true) {
             if (visible.sidebar() && album.isSmartID($albumID)) sidebar.toggle();
             if (album.json && albumID === album.json.id) {
 							view.album.title();
+							lychee.content.show();
 							tabindex.makeFocusable(lychee.content, true);
             } else {
 							album.load(albumID);

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -4,79 +4,80 @@
 
 let lychee = {
 
-	title: document.title,
-	version: '',
-	versionCode: '', // not really needed anymore
+    title: document.title,
+    version: '',
+    versionCode: '', // not really needed anymore
 
-	updatePath: 'https://LycheeOrg.github.io/update.json',
-	updateURL: 'https://github.com/LycheeOrg/Lychee/releases',
-	website: 'https://LycheeOrg.github.io',
+    updatePath: 'https://LycheeOrg.github.io/update.json',
+    updateURL: 'https://github.com/LycheeOrg/Lychee/releases',
+    website: 'https://LycheeOrg.github.io',
 
-	publicMode: false,
-	viewMode: false,
-	full_photo: true,
-	downloadable: false,
-	share_button_visible: false, // enable only v4+
-	api_V2: false, // enable api_V2
-	sub_albums: false, // enable sub_albums features
-	admin: false, // enable admin mode (multi-user)
-	upload: false, // enable possibility to upload (multi-user)
-	lock: false, // locked user (multi-user)
-	username: null,
-	layout: '1', // 0: Use default, "square" layout. 1: Use Flickr-like "justified" layout. 2: Use Google-like "unjustified" layout
-	public_search: false, // display Search in publicMode
-	image_overlay: false, // display Overlay like in Lightroom
-	image_overlay_default: false, // display Overlay like in Lightroom by default
-	image_overlay_type: 'exif', // current Overlay display type
-	image_overlay_type_default: 'exif', // image overlay type default type
-	map_display: false, // display photo coordinates on map
-	map_display_public: false, // display photos of public album on map (user not logged in)
-	map_provider: 'Wikimedia', // Provider of OSM Tiles
-	map_include_subalbums: false, // include photos of subalbums on map
-	location_decoding: false, // retrieve location name from GPS data
-	location_decoding_caching_type: 'Harddisk', // caching mode for GPS data decoding
-	location_show: false, // show location name
-	location_show_public: false, // show location name for public albums
+    publicMode: false,
+    viewMode: false,
+    full_photo: true,
+    downloadable: false,
+    share_button_visible: false, // enable only v4+
+    api_V2: false, // enable api_V2
+    sub_albums: false, // enable sub_albums features
+    admin: false, // enable admin mode (multi-user)
+    upload: false, // enable possibility to upload (multi-user)
+    lock: false, // locked user (multi-user)
+    username: null,
+    layout: '1', // 0: Use default, "square" layout. 1: Use Flickr-like "justified" layout. 2: Use Google-like "unjustified" layout
+    public_search: false, // display Search in publicMode
+    image_overlay: false, // display Overlay like in Lightroom
+    image_overlay_default: false, // display Overlay like in Lightroom by default
+    image_overlay_type: 'exif', // current Overlay display type
+    image_overlay_type_default: 'exif', // image overlay type default type
+    map_display: false, // display photo coordinates on map
+    map_display_public: false, // display photos of public album on map (user not logged in)
+    map_provider: 'Wikimedia', // Provider of OSM Tiles
+    map_include_subalbums: false, // include photos of subalbums on map
+    location_decoding: false, // retrieve location name from GPS data
+    location_decoding_caching_type: 'Harddisk', // caching mode for GPS data decoding
+    location_show: false, // show location name
+    location_show_public: false, // show location name for public albums
 
-	landing_page_enabled: false, // is landing page enabled ?
-	delete_imported: false,
+    landing_page_enabled: false, // is landing page enabled ?
+    delete_imported: false,
 
-	header_auto_hide : true,
-	active_focus_on_page_load : false,
-	enable_button_visibility : true,
-	enable_button_share : true,
-	enable_button_archive : true,
-	enable_button_move : true,
-	enable_button_trash : true,
-	enable_button_fullscreen : true,
-	enable_button_download : true,
-	enable_button_add : true,
-	enable_button_more : true,
-	enable_button_rotate : true,
-	enable_close_tab_on_esc : false,
-	enable_tabindex : false,
-	enable_contextmenu_header : true,
-	hide_content_during_imageview : false,
-	device_type: 'Desktop',
+    // this is device specific config, in this case default is Desktop.
+    header_auto_hide: true,
+    active_focus_on_page_load: false,
+    enable_button_visibility: true,
+    enable_button_share: true,
+    enable_button_archive: true,
+    enable_button_move: true,
+    enable_button_trash: true,
+    enable_button_fullscreen: true,
+    enable_button_download: true,
+    enable_button_add: true,
+    enable_button_more: true,
+    enable_button_rotate: true,
+    enable_close_tab_on_esc: false,
+    enable_tabindex: false,
+    enable_contextmenu_header: true,
+    hide_content_during_imageview: false,
+    device_type: 'Desktop',
 
-	checkForUpdates: '1',
-	update_json: 0,
-	update_available: false,
-	sortingPhotos: '',
-	sortingAlbums: '',
-	location: '',
+    checkForUpdates: '1',
+    update_json: 0,
+    update_available: false,
+    sortingPhotos: '',
+    sortingAlbums: '',
+    location: '',
 
-	lang: '',
-	lang_available: {},
+    lang: '',
+    lang_available: {},
 
-	dropbox: false,
-	dropboxKey: '',
+    dropbox: false,
+    dropboxKey: '',
 
-	content: $('.content'),
-	imageview: $('#imageview'),
-	footer: $('#footer'),
+    content: $('.content'),
+    imageview: $('#imageview'),
+    footer: $('#footer'),
 
-	locale: {}
+    locale: {}
 
 };
 
@@ -207,23 +208,23 @@ lychee.init = function() {
             lychee.share_button_visible = (data.config.share_button_visible && data.config.share_button_visible === '1') || false;
             lychee.delete_imported = (data.config.delete_imported && data.config.delete_imported === '1');
 
-						lychee.header_auto_hide          = data.config.header_auto_hide;
-						lychee.active_focus_on_page_load = data.config.active_focus_on_page_load;
-						lychee.enable_button_visibility    = data.config.enable_button_visibility;
-						lychee.enable_button_share         = data.config.enable_button_share;
-						lychee.enable_button_archive       = data.config.enable_button_archive;
-						lychee.enable_button_move          = data.config.enable_button_move;
-						lychee.enable_button_trash         = data.config.enable_button_trash;
-						lychee.enable_button_fullscreen    = data.config.enable_button_fullscreen;
-						lychee.enable_button_download      = data.config.enable_button_download;
-						lychee.enable_button_add           = data.config.enable_button_add;
-						lychee.enable_button_more          = data.config.enable_button_more;
-						lychee.enable_button_rotate        = data.config.enable_button_rotate;
-						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
-						lychee.enable_tabindex             = data.config.enable_tabindex;
-						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
-						lychee.hide_content_during_imgview = data.config.hide_content_during_imgview;
-						lychee.device_type                 = data.config.device_type;
+            lychee.header_auto_hide = data.config_device.header_auto_hide || true;
+            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load || false;
+            lychee.enable_button_visibility = data.config_device.enable_button_visibility || true;
+            lychee.enable_button_share = data.config_device.enable_button_share || true;
+            lychee.enable_button_archive = data.config_device.enable_button_archive || true;
+            lychee.enable_button_move = data.config_device.enable_button_move || true;
+            lychee.enable_button_trash = data.config_device.enable_button_trash || true;
+            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen || true;
+            lychee.enable_button_download = data.config_device.enable_button_download || true;
+            lychee.enable_button_add = data.config_device.enable_button_add || true;
+            lychee.enable_button_more = data.config_device.enable_button_more || true;
+            lychee.enable_button_rotate = data.config_device.enable_button_rotate || true;
+            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc || false;
+            lychee.enable_tabindex = data.config_device.enable_tabindex || false;
+            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
+            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
+            lychee.device_type = data.config_device.device_type || 'Desktop'; // we set default as Desktop
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
 
@@ -265,23 +266,23 @@ lychee.init = function() {
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
 
-						lychee.header_auto_hide          = data.config.header_auto_hide;
-						lychee.active_focus_on_page_load = data.config.active_focus_on_page_load;
-						lychee.enable_button_visibility    = data.config.enable_button_visibility;
-						lychee.enable_button_share         = data.config.enable_button_share;
-						lychee.enable_button_archive       = data.config.enable_button_archive;
-						lychee.enable_button_move          = data.config.enable_button_move;
-						lychee.enable_button_trash         = data.config.enable_button_trash;
-						lychee.enable_button_fullscreen    = data.config.enable_button_fullscreen;
-						lychee.enable_button_download      = data.config.enable_button_download;
-						lychee.enable_button_add           = data.config.enable_button_add;
-						lychee.enable_button_more          = data.config.enable_button_more;
-						lychee.enable_button_rotate        = data.config.enable_button_rotate;
-						lychee.enable_close_tab_on_esc     = data.config.enable_close_tab_on_esc;
-						lychee.enable_tabindex             = data.config.enable_tabindex;
-						lychee.enable_contextmenu_header   = data.config.enable_contextmenu_header;
-						lychee.hide_content_during_imgview = data.config.hide_content_during_imgview;
-						lychee.device_type                 = data.config.device_type;
+            lychee.header_auto_hide = data.config_device.header_auto_hide || true;
+            lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load || false;
+            lychee.enable_button_visibility = data.config_device.enable_button_visibility || true;
+            lychee.enable_button_share = data.config_device.enable_button_share || true;
+            lychee.enable_button_archive = data.config_device.enable_button_archive || true;
+            lychee.enable_button_move = data.config_device.enable_button_move || true;
+            lychee.enable_button_trash = data.config_device.enable_button_trash || true;
+            lychee.enable_button_fullscreen = data.config_device.enable_button_fullscreen || true;
+            lychee.enable_button_download = data.config_device.enable_button_download || true;
+            lychee.enable_button_add = data.config_device.enable_button_add || true;
+            lychee.enable_button_more = data.config_device.enable_button_more || true;
+            lychee.enable_button_rotate = data.config_device.enable_button_rotate || true;
+            lychee.enable_close_tab_on_esc = data.config_device.enable_close_tab_on_esc || false;
+            lychee.enable_tabindex = data.config_device.enable_tabindex || false;
+            lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
+            lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
+            lychee.device_type = data.config_device.device_type || 'Desktop'; // we set default as Desktop
 
             // console.log(lychee.full_photo);
             lychee.setMode('public');
@@ -326,12 +327,12 @@ lychee.login = function(data) {
 
 lychee.loginDialog = function() {
 
-  // Make background make unfocusable
-	tabindex.makeUnfocusable(header.dom());
-	tabindex.makeUnfocusable(lychee.content);
-	tabindex.makeUnfocusable(lychee.imageview);
+    // Make background make unfocusable
+    tabindex.makeUnfocusable(header.dom());
+    tabindex.makeUnfocusable(lychee.content);
+    tabindex.makeUnfocusable(lychee.imageview);
 
-	let msg = lychee.html`
+    let msg = lychee.html `
 			<form>
 				<p class='signIn'>
 					<input class='text' name='username' autocomplete='on' type='text' placeholder='$${ lychee.locale['USERNAME'] }' autocapitalize='off' data-tabindex='${tabindex.get_next_tab_index()}'>
@@ -341,27 +342,29 @@ lychee.loginDialog = function() {
 			</form>
 			`;
 
-	tab_index_login = tabindex.get_next_tab_index();
-	tab_index_cancel = tabindex.get_next_tab_index();
-	basicModal.show({
-		body: msg,
-		buttons: {
-			action: {
-				title: lychee.locale['SIGN_IN'],
-				fn: lychee.login,
-				attributes: [["data-tabindex", tabindex.get_next_tab_index()]]
-			},
-			cancel: {
-				title: lychee.locale['CANCEL'],
-				fn: basicModal.close,
-				attributes: [["data-tabindex", tabindex.get_next_tab_index()]]
-			}
-		}
-	});
+    basicModal.show({
+        body: msg,
+        buttons: {
+            action: {
+                title: lychee.locale['SIGN_IN'],
+                fn: lychee.login,
+                attributes: [
+                    ["data-tabindex", tabindex.get_next_tab_index()]
+                ]
+            },
+            cancel: {
+                title: lychee.locale['CANCEL'],
+                fn: basicModal.close,
+                attributes: [
+                    ["data-tabindex", tabindex.get_next_tab_index()]
+                ]
+            }
+        }
+    });
 
-	if (lychee.checkForUpdates==='1') lychee.getUpdate();
+    if (lychee.checkForUpdates === '1') lychee.getUpdate();
 
-	tabindex.makeFocusable(basicModal.dom());
+    tabindex.makeFocusable(basicModal.dom());
 
 };
 
@@ -403,7 +406,7 @@ lychee.load = function(autoplay = true) {
 
     contextMenu.close();
     multiselect.close();
-		tabindex.reset();
+    tabindex.reset();
 
     if (hash[0] != null) albumID = hash[0];
     if (hash[1] != null) photoID = hash[1];
@@ -469,14 +472,14 @@ lychee.load = function(autoplay = true) {
             }
             photo.load(photoID, albumID, autoplay);
 
-						// Make imageview focussable
-						tabindex.makeFocusable(lychee.imageview);
+            // Make imageview focussable
+            tabindex.makeFocusable(lychee.imageview);
 
-						// Make thumbnails unfocusable and store which element had focus
-						tabindex.makeUnfocusable(lychee.content, true);
+            // Make thumbnails unfocusable and store which element had focus
+            tabindex.makeUnfocusable(lychee.content, true);
 
-						// hide contentview if requested
-						if(lychee.hide_content_during_imgview) lychee.content.hide();
+            // hide contentview if requested
+            if (lychee.hide_content_during_imgview) lychee.content.hide();
 
             lychee.footer_hide();
         }
@@ -514,18 +517,18 @@ lychee.load = function(autoplay = true) {
 
             // Show Album
             if (visible.photo()) {
-							view.photo.hide();
-							tabindex.makeUnfocusable(lychee.imageview);
-						}
+                view.photo.hide();
+                tabindex.makeUnfocusable(lychee.imageview);
+            }
             if (visible.mapview()) mapview.close();
             if (visible.sidebar() && album.isSmartID($albumID)) sidebar.toggle();
             if (album.json && albumID === album.json.id) {
-							view.album.title();
-							lychee.content.show();
-							tabindex.makeFocusable(lychee.content, true);
+                view.album.title();
+                lychee.content.show();
+                tabindex.makeFocusable(lychee.content, true);
             } else {
-							album.load(albumID);
-						}
+                album.load(albumID);
+            }
             lychee.footer_show();
         }
 
@@ -547,9 +550,9 @@ lychee.load = function(autoplay = true) {
 
         // Show Albums
         if (visible.photo()) {
-					view.photo.hide();
-					tabindex.makeUnfocusable(lychee.imageview);
-				}
+            view.photo.hide();
+            tabindex.makeUnfocusable(lychee.imageview);
+        }
         if (visible.mapview()) mapview.close();
         lychee.content.show();
         lychee.footer_show();
@@ -742,10 +745,10 @@ lychee.loadDropbox = function(callback) {
 
 lychee.getEventName = function() {
 
-		if (lychee.device_type=='Mobile') {
-			return 'touchend';
-		}
-		return 'click';
+    if (lychee.device_type === 'Mobile') {
+        return 'touchend';
+    }
+    return 'click';
 };
 
 lychee.escapeHTML = function(html = '') {

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -58,7 +58,7 @@ let lychee = {
     enable_tabindex: false,
     enable_contextmenu_header: true,
     hide_content_during_imageview: false,
-    device_type: 'Desktop',
+    device_type: 'desktop',
 
     checkForUpdates: '1',
     update_json: 0,
@@ -224,7 +224,7 @@ lychee.init = function() {
             lychee.enable_tabindex = data.config_device.enable_tabindex || false;
             lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
             lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
-            lychee.device_type = data.config_device.device_type || 'Desktop'; // we set default as Desktop
+            lychee.device_type = data.config_device.device_type || 'desktop'; // we set default as Desktop
 
             lychee.editor_enabled = (data.config.editor_enabled && data.config.editor_enabled === '1') || false;
 
@@ -282,7 +282,7 @@ lychee.init = function() {
             lychee.enable_tabindex = data.config_device.enable_tabindex || false;
             lychee.enable_contextmenu_header = data.config_device.enable_contextmenu_header || true;
             lychee.hide_content_during_imgview = data.config_device.hide_content_during_imgview || false;
-            lychee.device_type = data.config_device.device_type || 'Desktop'; // we set default as Desktop
+            lychee.device_type = data.config_device.device_type || 'desktop'; // we set default as Desktop
 
             // console.log(lychee.full_photo);
             lychee.setMode('public');
@@ -745,7 +745,7 @@ lychee.loadDropbox = function(callback) {
 
 lychee.getEventName = function() {
 
-    if (lychee.device_type === 'Mobile') {
+    if (lychee.device_type === 'mobile') {
         return 'touchend';
     }
     return 'click';

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -41,6 +41,10 @@ let lychee = {
 	landing_page_enabled        : false,    // is landing page enabled ?
 	delete_imported				: false,
 
+	header_auto_hide : true,
+	history_update_for_photos : true,
+	enable_esc_for_exit : true,
+
 	checkForUpdates			: '1',
 	update_json 			: 0,
 	update_available		: false,
@@ -189,6 +193,10 @@ lychee.init = function() {
 			lychee.location_show		              = (data.config.location_show && data.config.location_show === '1')  || false;
 			lychee.location_show_public		        = (data.config.location_show_public && data.config.location_show_public === '1')  || false;
 
+			lychee.header_auto_hide          = data.config.header_auto_hide;
+			lychee.history_update_for_photos = data.config.history_update_for_photos;
+			lychee.enable_esc_for_exit       = data.config.enable_esc_for_exit;
+
 			lychee.default_license				= data.config.default_license	|| 'none';
 			lychee.css							= data.config.css				|| '';
 			lychee.full_photo					= (data.config.full_photo == null) || (data.config.full_photo === '1');
@@ -234,6 +242,10 @@ lychee.init = function() {
 			lychee.map_include_subalbums = (data.config.map_include_subalbums && data.config.map_include_subalbums === '1')  || false;
 			lychee.location_show		              = (data.config.location_show && data.config.location_show === '1')  || false;
 			lychee.location_show_public		        = (data.config.location_show_public && data.config.location_show_public === '1')  || false;
+
+			lychee.header_auto_hide          = data.config.header_auto_hide;
+			lychee.history_update_for_photos = data.config.history_update_for_photos;
+			lychee.enable_esc_for_exit       = data.config.enable_esc_for_exit;
 
 			// console.log(lychee.full_photo);
 			lychee.setMode('public');
@@ -281,13 +293,14 @@ lychee.loginDialog = function() {
 	let msg = lychee.html`
 			<form>
 				<p class='signIn'>
-					<input class='text' name='username' autocomplete='on' type='text' placeholder='$${ lychee.locale['USERNAME'] }' autocapitalize='off'>
-					<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$${ lychee.locale['PASSWORD'] }'>
+					<input class='text' name='username' autocomplete='on' type='text' placeholder='$${ lychee.locale['USERNAME'] }' autocapitalize='off' data-tabindex='${tabindex.get_next_tab_index()}'>
+					<input class='text' name='password' autocomplete='current-password' type='password' placeholder='$${ lychee.locale['PASSWORD'] }' data-tabindex='${tabindex.get_next_tab_index()}'>
 				</p>
-				<p class='version'>Lychee ${ lychee.version }<span> &#8211; <a target='_blank' href='${ lychee.updateURL }'>${ lychee.locale['UPDATE_AVAILABLE'] }</a><span></p>
+				<p class='version'>Lychee ${ lychee.version }<span> &#8211; <a target='_blank' href='${ lychee.updateURL }' data-tabindex='-1'>${ lychee.locale['UPDATE_AVAILABLE'] }</a><span></p>
 			</form>
 			`;
 
+	// TODO: Tabindex missing
 	basicModal.show({
 		body: msg,
 		buttons: {
@@ -321,6 +334,7 @@ lychee.goto = function(url = '', autoplay = true) {
 	url = '#' + url;
 
 	history.pushState(null, null, url);
+
 	lychee.load(autoplay)
 
 };
@@ -409,6 +423,10 @@ lychee.load = function(autoplay = true) {
 				album.load(albumID, true)
 			}
 			photo.load(photoID, albumID, autoplay);
+			// TODO: imageview not yet loaded
+			tabindex.makeFocusable(lychee.imageview);
+
+			tabindex.makeUnfocusable(lychee.content);
 			lychee.footer_hide();
 		}
 
@@ -444,11 +462,18 @@ lychee.load = function(autoplay = true) {
 			photo.json = null;
 
 			// Show Album
-			if (visible.photo()) view.photo.hide();
+			if (visible.photo()) {
+				view.photo.hide();
+				tabindex.makeUnfocusable(lychee.imageview);
+			}
 			if (visible.mapview()) mapview.close();
 			if (visible.sidebar() && (albumID==='0' || albumID==='f' || albumID==='s' || albumID==='r')) sidebar.toggle();
-			if (album.json && albumID===album.json.id) view.album.title();
-			else album.load(albumID);
+			if (album.json && albumID===album.json.id) {
+				view.album.title();
+				tabindex.makeFocusable(lychee.content);
+			} else {
+				album.load(albumID);
+			}
 			lychee.footer_show();
 		}
 
@@ -469,7 +494,10 @@ lychee.load = function(autoplay = true) {
 		if (visible.sidebar()) sidebar.toggle();
 
 		// Show Albums
-		if (visible.photo()) view.photo.hide();
+		if (visible.photo()) {
+			view.photo.hide();
+			tabindex.makeUnfocusable(lychee.imageview);
+		}
 		if (visible.mapview()) mapview.close();
 		lychee.content.show();
 		lychee.footer_show();

--- a/scripts/main/mapview.js
+++ b/scripts/main/mapview.js
@@ -302,6 +302,9 @@ mapview.close = function() {
 	$('#mapview').hide();
 	header.setMode('album');
 
+	// Make album focussable
+	tabindex.makeFocusable(lychee.content);
+
 };
 
 mapview.goto = function(elem) {

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -67,11 +67,12 @@ photo.load = function(photoID, albumID, autoplay) {
 		view.photo.init(autoplay);
 		lychee.imageview.show();
 
-		setTimeout(() => {
-			lychee.content.show();
-			tabindex.makeUnfocusable(lychee.content);
-		}, 300)
-
+		if (!lychee.hide_content_during_imgview) {
+			setTimeout(() => {
+				lychee.content.show();
+				tabindex.makeUnfocusable(lychee.content);
+			}, 300);
+		}
 	})
 
 };

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -68,7 +68,8 @@ photo.load = function(photoID, albumID, autoplay) {
 		lychee.imageview.show();
 
 		setTimeout(() => {
-			lychee.content.show()
+			lychee.content.show();
+			tabindex.makeUnfocusable(lychee.content);
 		}, 300)
 
 	})

--- a/scripts/main/tabindex.js
+++ b/scripts/main/tabindex.js
@@ -23,6 +23,9 @@ tabindex.saveSettings = function(elem) {
 }
 
 tabindex.restoreSettings = function(elem) {
+
+	if(!lychee.enable_tabindex) return;
+
 	// Todo: Make shorter noation
 	// Get all elements which have a tabindex
 	tmp = $(elem).find("[tabindex]");
@@ -35,7 +38,25 @@ tabindex.restoreSettings = function(elem) {
 	});
 }
 
-tabindex.makeUnfocusable = function(elem) {
+tabindex.makeUnfocusable = function(elem, saveFocusElement = false) {
+
+	// Todo: Make shorter noation
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[tabindex]");
+
+	// iterate over all elements and set tabindex to -1 (i.e. make is not focussable)
+	tmp.each(function(i, e) {
+		$(e).attr("tabindex", "-1");
+		// Save which element had focus before we make it unfocusable
+		if (saveFocusElement && $(e).is(":focus")) {
+			$(e).data("tabindex-focus", true);
+			// Remove focus
+			$(e).blur();
+		}
+	});
+};
+
+tabindex.makeUnfocusablePermanent = function(elem) {
 
 	// Todo: Make shorter noation
 	// Get all elements which have a tabindex
@@ -46,9 +67,17 @@ tabindex.makeUnfocusable = function(elem) {
 		$(e).attr("tabindex", "-1");
 	});
 
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[data-tabindex]");
+
+	tmp.each(function(i, e) {
+		$(e).data("tabindex", "-1");
+	});
 };
 
-tabindex.makeFocusable = function(elem) {
+tabindex.makeFocusable = function(elem, restoreFocusElement = false) {
+
+	if(!lychee.enable_tabindex) return;
 
 	// Todo: Make shorter noation
 	// Get all elements which have a tabindex
@@ -57,6 +86,13 @@ tabindex.makeFocusable = function(elem) {
 	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
 	tmp.each(function(i, e) {
 		$(e).attr("tabindex", $(e).data("tabindex"));
+		// restore focus elemente if wanted
+		if(restoreFocusElement) {
+			if($(e).data("tabindex-focus") && lychee.active_focus_on_page_load) {
+				$(e).focus();
+				$(e).removeData("tabindex-focus");
+			}
+		}
 	});
 
 };

--- a/scripts/main/tabindex.js
+++ b/scripts/main/tabindex.js
@@ -9,6 +9,58 @@ let tabindex = {
 
 };
 
+tabindex.saveSettings = function(elem) {
+	// Todo: Make shorter noation
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[tabindex]");
+
+	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+	tmp.each(function(i, e) {
+		// TODO: shorter notation
+		a = $(e).attr("tabindex");
+		$(this).data("tabindex-saved", a);
+	});
+}
+
+tabindex.restoreSettings = function(elem) {
+	// Todo: Make shorter noation
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[tabindex]");
+
+	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+	tmp.each(function(i, e) {
+		// TODO: shorter notation
+		a = $(e).data("tabindex-saved");
+		$(e).attr("tabindex", a);
+	});
+}
+
+tabindex.makeUnfocusable = function(elem) {
+
+	// Todo: Make shorter noation
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[tabindex]");
+
+	// iterate over all elements and set tabindex to -1 (i.e. make is not focussable)
+	tmp.each(function(i, e) {
+		$(e).attr("tabindex", "-1");
+	});
+
+};
+
+tabindex.makeFocusable = function(elem) {
+
+	// Todo: Make shorter noation
+	// Get all elements which have a tabindex
+	tmp = $(elem).find("[data-tabindex]");
+
+	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+	tmp.each(function(i, e) {
+		$(e).attr("tabindex", $(e).data("tabindex"));
+	});
+
+};
+
 tabindex.get_next_tab_index = function() {
 
 	tabindex.next_tab_index = tabindex.next_tab_index + 1;

--- a/scripts/main/tabindex.js
+++ b/scripts/main/tabindex.js
@@ -4,8 +4,8 @@
 
 let tabindex = {
 
-	offset_for_header : 20,
-	next_tab_index : 20
+	offset_for_header : 100,
+	next_tab_index : 100
 
 };
 
@@ -54,25 +54,10 @@ tabindex.makeUnfocusable = function(elem, saveFocusElement = false) {
 			$(e).blur();
 		}
 	});
-};
 
-tabindex.makeUnfocusablePermanent = function(elem) {
+	// Disable input fields
+	$(elem).find("input").attr("disabled","disabled");
 
-	// Todo: Make shorter noation
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[tabindex]");
-
-	// iterate over all elements and set tabindex to -1 (i.e. make is not focussable)
-	tmp.each(function(i, e) {
-		$(e).attr("tabindex", "-1");
-	});
-
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[data-tabindex]");
-
-	tmp.each(function(i, e) {
-		$(e).data("tabindex", "-1");
-	});
 };
 
 tabindex.makeFocusable = function(elem, restoreFocusElement = false) {
@@ -95,6 +80,8 @@ tabindex.makeFocusable = function(elem, restoreFocusElement = false) {
 		}
 	});
 
+	// Enable input fields
+	$(elem).find("input").removeAttr("disabled");
 };
 
 tabindex.get_next_tab_index = function() {
@@ -110,87 +97,5 @@ tabindex.reset = function() {
 	tabindex.next_tab_index = tabindex.offset_for_header;
 
 	return;
-
-};
-
-tabindex.get_right_tab_index = function() {
-
-	// Get current focussed element
-	focus_elem = $(':focus');
-
-	right_tab_idx = 0;
-
-	var tab_idx = [];
-	// create array of all tab index
-	$("[tabindex]").each (function (i, e) {
-		if($(e).is(":visible")) {
-			tab_idx.push(parseInt($(e).attr('tabindex')));
-		}
-	});
-
-	// sort it
-	tab_idx.sort((a,b) => a-b);
-
-	if (focus_elem !== 0 ){
-		current_tab_idx = parseInt($(':focus').attr('tabindex'));
-
-		// Get index of current_tab_idx;
-		array_idx_current_tab_idx = tab_idx.indexOf(current_tab_idx);
-
-		if (array_idx_current_tab_idx == tab_idx.length-1) {
-			// focus has been on last element -> select first one
-			right_tab_idx = tab_idx[0];
-		} else {
-			// Next one
-			right_tab_idx = tab_idx[array_idx_current_tab_idx + 1];
-		}
-
-	} else {
-		// there has been no focus  -> select first one
-		right_tab_idx = tab_idx[0];
-	}
-
-	return right_tab_idx;
-
-};
-
-tabindex.get_left_tab_index = function() {
-
-	// Get current focussed element
-	focus_elem = $(':focus');
-
-	right_tab_idx = 0;
-
-	var tab_idx = [];
-	// create array of all tab index
-	$("[tabindex]").each (function (i, e) {
-		if($(e).is(":visible")) {
-			tab_idx.push(parseInt($(e).attr('tabindex')));
-		}
-	});
-
-	// sort it
-	tab_idx.sort((a,b) => a-b);
-
-	if (focus_elem !== 0 ){
-		current_tab_idx = parseInt($(':focus').attr('tabindex'));
-
-		// Get index of current_tab_idx;
-		array_idx_current_tab_idx = tab_idx.indexOf(current_tab_idx);
-
-		if (array_idx_current_tab_idx == 0) {
-			// focus has been on first element -> select last one
-			right_tab_idx = tab_idx[tab_idx.length-1];
-		} else {
-			// Previous one
-			right_tab_idx = tab_idx[array_idx_current_tab_idx - 1];
-		}
-
-	} else {
-		// there has been no focus  -> select last one
-		right_tab_idx = tab_idx[tab_idx.length-1];
-	}
-
-	return right_tab_idx;
 
 };

--- a/scripts/main/tabindex.js
+++ b/scripts/main/tabindex.js
@@ -4,98 +4,96 @@
 
 let tabindex = {
 
-	offset_for_header : 100,
-	next_tab_index : 100
+    offset_for_header: 100,
+    next_tab_index: 100
 
 };
 
 tabindex.saveSettings = function(elem) {
-	// Todo: Make shorter noation
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[tabindex]");
+    // Todo: Make shorter notation
+    // Get all elements which have a tabindex
+    let tmp = $(elem).find("[tabindex]");
 
-	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
-	tmp.each(function(i, e) {
-		// TODO: shorter notation
-		a = $(e).attr("tabindex");
-		$(this).data("tabindex-saved", a);
-	});
+    // iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+    tmp.each(function(i, e) {
+        // TODO: shorter notation
+        a = $(e).attr("tabindex");
+        $(this).data("tabindex-saved", a);
+    });
 }
 
 tabindex.restoreSettings = function(elem) {
 
-	if(!lychee.enable_tabindex) return;
+    if (!lychee.enable_tabindex) return;
 
-	// Todo: Make shorter noation
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[tabindex]");
+    // Todo: Make shorter noation
+    // Get all elements which have a tabindex
+    let tmp = $(elem).find("[tabindex]");
 
-	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
-	tmp.each(function(i, e) {
-		// TODO: shorter notation
-		a = $(e).data("tabindex-saved");
-		$(e).attr("tabindex", a);
-	});
+    // iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+    tmp.each(function(i, e) {
+        // TODO: shorter notation
+        a = $(e).data("tabindex-saved");
+        $(e).attr("tabindex", a);
+    });
 }
 
 tabindex.makeUnfocusable = function(elem, saveFocusElement = false) {
 
-	// Todo: Make shorter noation
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[tabindex]");
+    // Todo: Make shorter noation
+    // Get all elements which have a tabindex
+    let tmp = $(elem).find("[tabindex]");
 
-	// iterate over all elements and set tabindex to -1 (i.e. make is not focussable)
-	tmp.each(function(i, e) {
-		$(e).attr("tabindex", "-1");
-		// Save which element had focus before we make it unfocusable
-		if (saveFocusElement && $(e).is(":focus")) {
-			$(e).data("tabindex-focus", true);
-			// Remove focus
-			$(e).blur();
-		}
-	});
+    // iterate over all elements and set tabindex to -1 (i.e. make is not focussable)
+    tmp.each(function(i, e) {
+        $(e).attr("tabindex", "-1");
+        // Save which element had focus before we make it unfocusable
+        if (saveFocusElement && $(e).is(":focus")) {
+            $(e).data("tabindex-focus", true);
+            // Remove focus
+            $(e).blur();
+        }
+    });
 
-	// Disable input fields
-	$(elem).find("input").attr("disabled","disabled");
+    // Disable input fields
+    $(elem).find("input").attr("disabled", "disabled");
 
 };
 
 tabindex.makeFocusable = function(elem, restoreFocusElement = false) {
 
-	if(!lychee.enable_tabindex) return;
+    if (!lychee.enable_tabindex) return;
 
-	// Todo: Make shorter noation
-	// Get all elements which have a tabindex
-	tmp = $(elem).find("[data-tabindex]");
+    // Todo: Make shorter noation
+    // Get all elements which have a tabindex
+    let tmp = $(elem).find("[data-tabindex]");
 
-	// iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
-	tmp.each(function(i, e) {
-		$(e).attr("tabindex", $(e).data("tabindex"));
-		// restore focus elemente if wanted
-		if(restoreFocusElement) {
-			if($(e).data("tabindex-focus") && lychee.active_focus_on_page_load) {
-				$(e).focus();
-				$(e).removeData("tabindex-focus");
-			}
-		}
-	});
+    // iterate over all elements and set tabindex to stored value (i.e. make is not focussable)
+    tmp.each(function(i, e) {
+        $(e).attr("tabindex", $(e).data("tabindex"));
+        // restore focus elemente if wanted
+        if (restoreFocusElement) {
+            if ($(e).data("tabindex-focus") && lychee.active_focus_on_page_load) {
+                $(e).focus();
+                $(e).removeData("tabindex-focus");
+            }
+        }
+    });
 
-	// Enable input fields
-	$(elem).find("input").removeAttr("disabled");
+    // Enable input fields
+    $(elem).find("input").removeAttr("disabled");
 };
 
 tabindex.get_next_tab_index = function() {
 
-	tabindex.next_tab_index = tabindex.next_tab_index + 1;
+    tabindex.next_tab_index = tabindex.next_tab_index + 1;
 
-	return (tabindex.next_tab_index-1);
+    return (tabindex.next_tab_index - 1);
 
 };
 
 tabindex.reset = function() {
 
 	tabindex.next_tab_index = tabindex.offset_for_header;
-
-	return;
-
+	
 };

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -575,7 +575,7 @@ view.photo = {
 		$(document).bind('mousemove', function () {
 			clearTimeout(timeout);
 			// For live Photos: header animtion only if LivePhoto is not playing
-			if(!photo.isLivePhotoPlaying()) {
+			if(!photo.isLivePhotoPlaying() && lychee.header_auto_hide) {
 				header.show();
 				timeout = setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
 			}
@@ -585,7 +585,10 @@ view.photo = {
 		});
 
 		// we also put this timeout to enable it by default when you directly click on a picture.
-		setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
+		if(lychee.header_auto_hide) {
+			setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
+		}
+
 
 		lychee.animate(lychee.imageview, 'fadeIn')
 
@@ -702,6 +705,7 @@ view.photo = {
 
 		let ret = build.imageview(photo.json, visible.header(), autoplay);
 		lychee.imageview.html(ret.html);
+		tabindex.makeFocusable(lychee.imageview);
 
 		// Init Live Photo if needed
 		if (photo.isLivePhoto()) {

--- a/styles/devices/TV.scss
+++ b/styles/devices/TV.scss
@@ -1,26 +1,40 @@
-.setLogin, .setSorting, .setDropBox, .setLang, .setLayout, .setPublicSearch, .setOverlay, .setOverlayType, .setMapDisplay, .setMapDisplayPublic, .setMapProvider, .setMapIncludeSubalbums, .setLocationDecoding, .setLocationDecodingCachingType, .setLocationShow, .setLocationShowPublic, .setDefaultLicense, .setCSS {
-
-	.basicModal__button:focus {
+.basicModal__button:focus {
 		background: #2293EC;
 		color: #FFFFFF;
 		cursor: pointer;
 		outline-style: none;
-	}
-
 }
 
-.content {
+.basicModal__button#basicModal__action:focus {
+		color: #FFFFFF;
+}
 
-	.photo {
-		&:focus {
+.content .photo:focus {
 			outline-style: solid;
-			outline-color: $colorBlue;
+			outline-color: #FFFFFF;
 			outline-width: 10px;
-		}
+}
 
-		&:focus .thumbimg {
-			border-color: $colorBlue;
-		}
-	}
+.content .album:focus {
+			outline-width: 0;
+}
 
+.header .button:focus {
+				outline-width: 0;
+				background-color: #FFFFFF;
+}
+
+.header__title:focus {
+				outline-width: 0;
+				background-color: #FFFFFF;
+				color: #000000;
+}
+
+.header .button:focus .iconic {
+				fill: #000000;
+}
+
+#imageview #image,
+#imageview #livephoto {
+	outline-width: 0;
 }

--- a/styles/devices/TV.scss
+++ b/styles/devices/TV.scss
@@ -1,0 +1,26 @@
+.setLogin, .setSorting, .setDropBox, .setLang, .setLayout, .setPublicSearch, .setOverlay, .setOverlayType, .setMapDisplay, .setMapDisplayPublic, .setMapProvider, .setMapIncludeSubalbums, .setLocationDecoding, .setLocationDecodingCachingType, .setLocationShow, .setLocationShowPublic, .setDefaultLicense, .setCSS {
+
+	.basicModal__button:focus {
+		background: #2293EC;
+		color: #FFFFFF;
+		cursor: pointer;
+		outline-style: none;
+	}
+
+}
+
+.content {
+
+	.photo {
+		&:focus {
+			outline-style: solid;
+			outline-color: $colorBlue;
+			outline-width: 10px;
+		}
+
+		&:focus .thumbimg {
+			border-color: $colorBlue;
+		}
+	}
+
+}

--- a/styles/devices/TV.scss
+++ b/styles/devices/TV.scss
@@ -34,6 +34,9 @@
 				fill: #000000;
 }
 
+#imageview {
+	background-color: #000000;
+}
 #imageview #image,
 #imageview #livephoto {
 	outline-width: 0;

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -79,12 +79,6 @@
 			border-color: $colorBlue;
 		}
 
-		&:focus {
-			outline-style: solid;
-			outline-color: $colorBlue;
-			outline-width: 10px;
-		}
-
 		&:active .thumbimg {
 			transition: none;
 			border-color: darken($colorBlue, 15%);

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -74,6 +74,7 @@
 		}
 
 		&:hover .thumbimg,
+		&:focus .thumbimg,
 		&.active .thumbimg {
 			border-color: $colorBlue;
 		}
@@ -98,7 +99,8 @@
 				transition: all 0.3s;
 				will-change: opacity, height;
 			}
-			&:hover::before {
+			&:hover::before,
+			&:focus::before, {
 				opacity: 0.75;
 			}
 		}
@@ -115,7 +117,8 @@
 				transition: all 0.3s;
 				will-change: opacity, height;
 			}
-			&:hover::before {
+			&:hover::before,
+			&:focus::before, {
 				opacity: 0.75;
 			}
 		}
@@ -130,7 +133,9 @@
 		}
 
 		&:hover .thumbimg:nth-child(1),
-		&:hover .thumbimg:nth-child(2) {
+		&:hover .thumbimg:nth-child(2),
+		&:focus .thumbimg:nth-child(1),
+		&:focus .thumbimg:nth-child(2) {
 			opacity: 1;
 			// Keep the composited layer created by the browser during the animation.
 			// Makes the border of the transformed thumb look better.
@@ -138,11 +143,13 @@
 			will-change: transform;
 		}
 
-		&:hover .thumbimg:nth-child(1) {
+		&:hover .thumbimg:nth-child(1),
+		&:focus .thumbimg:nth-child(1) {
 			transform: rotate(-2deg) translateY(10px) translateX(-12px);
 		}
 
-		&:hover .thumbimg:nth-child(2) {
+		&:hover .thumbimg:nth-child(2),
+		&:focus .thumbimg:nth-child(2) {
 			transform: rotate(5deg) translateY(-8px) translateX(12px);
 		}
 	}
@@ -167,6 +174,7 @@
 	}
 
 	.photo:hover .overlay,
+	.photo:focus .overlay,
 	.photo.active .overlay {
 		opacity: 1;
 	}

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -79,6 +79,12 @@
 			border-color: $colorBlue;
 		}
 
+		&:focus {
+			outline-style: solid;
+			outline-color: $colorBlue;
+			outline-width: 10px;
+		}
+
 		&:active .thumbimg {
 			transition: none;
 			border-color: darken($colorBlue, 15%);


### PR DESCRIPTION
This PR adds basic support to view Lychee on a FireTV as a WebApp.

In a nutshell:
* Navigation is done using the 'tabindex' property of elements
* We need to enable/disable this features as element can be focused even if they are not visible 
* Several navigation elements are disabled since they are not needed on a TV
* Device specific CSS (using white to highlight nav elements) used
* FireTV doesn't like transparency and several layers of elements on top of each other (performance) 
* UI for Desktop and mobile remains unchanged