### PR TITLE
When swiping on a photo on a mobile device, the user will navigate be…

### DIFF
--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -183,7 +183,7 @@ $(document).ready(function() {
 		});
 	$('#imageview')
 		// Swipe on mobile
-		.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto')) })
+		.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto'), true) })
 		.swipe().on('swipeMove',  function(e) { if (visible.photo()) swipe.move(e.swipe) })
 		.swipe().on('swipeEnd',   function(e) { if (visible.photo()) swipe.stop(e.swipe, photo.previous, photo.next) })
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -183,7 +183,7 @@ $(document).ready(function() {
 		});
 	$('#imageview')
 		// Swipe on mobile
-		.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto'), true) })
+		.swipe().on('swipeStart', function() { if (visible.photo()) swipe.start($('#imageview #image, #imageview #livephoto')) })
 		.swipe().on('swipeMove',  function(e) { if (visible.photo()) swipe.move(e.swipe) })
 		.swipe().on('swipeEnd',   function(e) { if (visible.photo()) swipe.stop(e.swipe, photo.previous, photo.next) })
 

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -37,6 +37,8 @@ let lychee = {
     location_decoding_caching_type: 'Harddisk', // caching mode for GPS data decoding
     location_show: false, // show location name
     location_show_public: false, // show location name for public albums
+    swipe_tolerance_x: 150, // tolerance for navigating when swiping images to the left and right on mobile
+    swipe_tolerance_y: 250, // tolerance for navigating when swiping images up and down
 
     landing_page_enabled: false, // is landing page enabled ?
     delete_imported: false,
@@ -200,6 +202,8 @@ lychee.init = function() {
             lychee.location_decoding_caching_type = (!data.config.location_decoding_caching_type) ? 'Harddisk' : data.config.location_decoding_caching_type;
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
+            lychee.swipe_tolerance_x = (data.config.swipe_tolerance_x && parseInt(data.config.swipe_tolerance_x) !== NaN && parseInt(data.config.swipe_tolerance_x)) || 150;
+            lychee.swipe_tolerance_y = (data.config.swipe_tolerance_y && parseInt(data.config.swipe_tolerance_y) !== NaN && parseInt(data.config.swipe_tolerance_y)) || 250;
 
             lychee.default_license = data.config.default_license || 'none';
             lychee.css = data.config.css || '';
@@ -265,6 +269,8 @@ lychee.init = function() {
             lychee.map_include_subalbums = (data.config.map_include_subalbums && data.config.map_include_subalbums === '1') || false;
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
+            lychee.swipe_tolerance_x = (data.config.swipe_tolerance_x && parseInt(data.config.swipe_tolerance_x) !== NaN && parseInt(data.config.swipe_tolerance_x)) || 150;
+            lychee.swipe_tolerance_y = (data.config.swipe_tolerance_y && parseInt(data.config.swipe_tolerance_y) !== NaN && parseInt(data.config.swipe_tolerance_y)) || 250;
 
             lychee.header_auto_hide = data.config_device.header_auto_hide;
             lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load;

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -173,6 +173,9 @@ lychee.init = function() {
             header.applyTranslations();
         }
 
+        const validatedSwipeToleranceX = (data.config.swipe_tolerance_x && !isNaN(parseInt(data.config.swipe_tolerance_x)) && parseInt(data.config.swipe_tolerance_x)) || 150;
+        const validatedSwipeToleranceY = (data.config.swipe_tolerance_y && !isNaN(parseInt(data.config.swipe_tolerance_y)) && parseInt(data.config.swipe_tolerance_y)) || 250;
+
         // Check status
         // 0 = No configuration
         // 1 = Logged out
@@ -202,8 +205,8 @@ lychee.init = function() {
             lychee.location_decoding_caching_type = (!data.config.location_decoding_caching_type) ? 'Harddisk' : data.config.location_decoding_caching_type;
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
-            lychee.swipe_tolerance_x = (data.config.swipe_tolerance_x && parseInt(data.config.swipe_tolerance_x) !== NaN && parseInt(data.config.swipe_tolerance_x)) || 150;
-            lychee.swipe_tolerance_y = (data.config.swipe_tolerance_y && parseInt(data.config.swipe_tolerance_y) !== NaN && parseInt(data.config.swipe_tolerance_y)) || 250;
+            lychee.swipe_tolerance_x = validatedSwipeToleranceX;
+            lychee.swipe_tolerance_y = validatedSwipeToleranceY;
 
             lychee.default_license = data.config.default_license || 'none';
             lychee.css = data.config.css || '';
@@ -269,8 +272,8 @@ lychee.init = function() {
             lychee.map_include_subalbums = (data.config.map_include_subalbums && data.config.map_include_subalbums === '1') || false;
             lychee.location_show = (data.config.location_show && data.config.location_show === '1') || false;
             lychee.location_show_public = (data.config.location_show_public && data.config.location_show_public === '1') || false;
-            lychee.swipe_tolerance_x = (data.config.swipe_tolerance_x && parseInt(data.config.swipe_tolerance_x) !== NaN && parseInt(data.config.swipe_tolerance_x)) || 150;
-            lychee.swipe_tolerance_y = (data.config.swipe_tolerance_y && parseInt(data.config.swipe_tolerance_y) !== NaN && parseInt(data.config.swipe_tolerance_y)) || 250;
+            lychee.swipe_tolerance_x = validatedSwipeToleranceX;
+            lychee.swipe_tolerance_y = validatedSwipeToleranceY;
 
             lychee.header_auto_hide = data.config_device.header_auto_hide;
             lychee.active_focus_on_page_load = data.config_device.active_focus_on_page_load;

--- a/scripts/main/swipe.js
+++ b/scripts/main/swipe.js
@@ -7,19 +7,12 @@ let swipe = {
 	obj            : null,
 	offsetX        : 0,
 	offsetY        : 0,
-	preventNextHeaderToggle : false,
-	disable_Y_drag : false
-
+	preventNextHeaderToggle : false
 };
 
-swipe.start = function(obj, disable_Y_drag) {
+swipe.start = function(obj) {
 	if (obj)            swipe.obj         	 = obj;
-
- 	// this will be set for swipe-navigating photos, so the user is not confused by the photo moving up or down
-	if (disable_Y_drag === true) swipe.disable_Y_drag = disable_Y_drag;
-
 	return true
-
 };
 
 swipe.move = function(e) {
@@ -37,22 +30,12 @@ swipe.move = function(e) {
 	  swipe.offsetY = +1 * e.y;
 	}
 
-	if (swipe.disable_Y_drag) {
-		const value = 'translate(' + swipe.offsetX + 'px, 0px)';
-		swipe.obj.css({
-			'WebkitTransform' : value,
-			'MozTransform'    : value,
-			'transform'       : value
-		})
-	} else {
-		const value = 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)';
-		swipe.obj.css({
-			'WebkitTransform' : value,
-			'MozTransform'    : value,
-			'transform'       : value
-		})
-	}
-
+	const value = 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)';
+	swipe.obj.css({
+		'WebkitTransform' : value,
+		'MozTransform'    : value,
+		'transform'       : value
+	})
 	return;
 
 };
@@ -96,7 +79,7 @@ swipe.stop = function(e, left, right) {
 		swipe.obj.css({
 			WebkitTransform : value,
 			MozTransform    : value,
-			transform       : value 
+			transform       : value
 		})
 
 	}
@@ -104,7 +87,6 @@ swipe.stop = function(e, left, right) {
 	swipe.obj            = null;
 	swipe.offsetX        = 0;
 	swipe.offsetY        = 0
-	swipe.disable_Y_drag = false;
 
 	return;
 };

--- a/scripts/main/swipe.js
+++ b/scripts/main/swipe.js
@@ -5,19 +5,18 @@
 let swipe = {
 
 	obj            : null,
-	tolerance_X    : 150,
-	tolerance_Y    : 250,
 	offsetX        : 0,
 	offsetY        : 0,
-	preventNextHeaderToggle : false
+	preventNextHeaderToggle : false,
+	disable_Y_drag : false
 
 };
 
-swipe.start = function(obj, tolerance_X, tolerance_Y) {
+swipe.start = function(obj, disable_Y_drag) {
+	if (obj)            swipe.obj         	 = obj;
 
-	if (obj)            swipe.obj         = obj;
-	if (tolerance_X)    swipe.tolerance_X = tolerance_X;
-	if (tolerance_Y)    swipe.tolerance_Y = tolerance_Y;
+ 	// this will be set for swipe-navigating photos, so the user is not confused by the photo moving up or down
+	if (disable_Y_drag === true) swipe.disable_Y_drag = disable_Y_drag; 
 
 	return true
 
@@ -38,11 +37,19 @@ swipe.move = function(e) {
 	  swipe.offsetY = +1 * e.y;
 	}
 
-	swipe.obj.css({
-		'WebkitTransform' : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
-		'MozTransform'    : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
-		'transform'       : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)'
-	})
+	if (swipe.disable_Y_drag) {
+		swipe.obj.css({
+			'WebkitTransform' : 'translate(' + swipe.offsetX + 'px, 0px)',
+			'MozTransform'    : 'translate(' + swipe.offsetX + 'px, 0px)',
+			'transform'       : 'translate(' + swipe.offsetX + 'px, 0px)'
+		})
+	} else {
+		swipe.obj.css({
+			'WebkitTransform' : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
+			'MozTransform'    : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
+			'transform'       : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)'
+		})
+	}
 
 	return;
 
@@ -56,15 +63,15 @@ swipe.stop = function(e, left, right) {
 		return false;
 	}
 
-	if (e.y<=-swipe.tolerance_Y) {
+	if (e.y<=-lychee.swipe_tolerance_y) {
 
       lychee.goto(album.getID());
 
-	} else if (e.y>=swipe.tolerance_Y) {
+	} else if (e.y>=lychee.swipe_tolerance_y) {
 
      lychee.goto(album.getID());
 
-	} else if (e.x<=-swipe.tolerance_X) {
+	} else if (e.x<=-lychee.swipe_tolerance_x) {
 
 		left(true);
 
@@ -73,7 +80,7 @@ swipe.stop = function(e, left, right) {
 		// the toggling of the header
 		swipe.preventNextHeaderToggle = true;
 
-	} else if (e.x>=swipe.tolerance_X) {
+	} else if (e.x>=lychee.swipe_tolerance_x) {
 
 		right(true);
 
@@ -95,6 +102,7 @@ swipe.stop = function(e, left, right) {
 	swipe.obj            = null;
 	swipe.offsetX        = 0;
 	swipe.offsetY        = 0
+	swipe.disable_Y_drag = false;
 
 	return;
 };

--- a/scripts/main/swipe.js
+++ b/scripts/main/swipe.js
@@ -16,7 +16,7 @@ swipe.start = function(obj, disable_Y_drag) {
 	if (obj)            swipe.obj         	 = obj;
 
  	// this will be set for swipe-navigating photos, so the user is not confused by the photo moving up or down
-	if (disable_Y_drag === true) swipe.disable_Y_drag = disable_Y_drag; 
+	if (disable_Y_drag === true) swipe.disable_Y_drag = disable_Y_drag;
 
 	return true
 
@@ -38,16 +38,18 @@ swipe.move = function(e) {
 	}
 
 	if (swipe.disable_Y_drag) {
+		const value = 'translate(' + swipe.offsetX + 'px, 0px)';
 		swipe.obj.css({
-			'WebkitTransform' : 'translate(' + swipe.offsetX + 'px, 0px)',
-			'MozTransform'    : 'translate(' + swipe.offsetX + 'px, 0px)',
-			'transform'       : 'translate(' + swipe.offsetX + 'px, 0px)'
+			'WebkitTransform' : value,
+			'MozTransform'    : value,
+			'transform'       : value
 		})
 	} else {
+		const value = 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)';
 		swipe.obj.css({
-			'WebkitTransform' : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
-			'MozTransform'    : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)',
-			'transform'       : 'translate(' + swipe.offsetX + 'px, ' +  swipe.offsetY + 'px)'
+			'WebkitTransform' : value,
+			'MozTransform'    : value,
+			'transform'       : value
 		})
 	}
 
@@ -90,11 +92,11 @@ swipe.stop = function(e, left, right) {
 		swipe.preventNextHeaderToggle = true;
 
 	} else {
-
+		const value = 'translate(0px, 0px)';
 		swipe.obj.css({
-			WebkitTransform : 'translate(0px, 0px)',
-			MozTransform    : 'translate(0px, 0px)',
-			transform       : 'translate(0px, 0px)'
+			WebkitTransform : value,
+			MozTransform    : value,
+			transform       : value 
 		})
 
 	}


### PR DESCRIPTION
…tween photos based on a pixel-threshold of the swipe gesture. This change should make it possible to configure this threshold via backend-config. the original values (and thus behavior) will be kept as defaults in case the backend is not migrated yet or the values are not adjusted.

Additionally when swiping up and down on a photo the drag-animation is
disabled as to not confuse a user on a small mobile-device screen. This
is especially interesting when zooming in and out of a photo

Related backend changes are found in pullrequest #677