### PR TITLE
Don't rely on cameraDate

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -208,7 +208,7 @@ build.photo = function (data, disabled = false) {
 					<h1 title='$${data.title}'>$${data.title}</h1>
 			`;
 
-	if (data.cameraDate === '1') html += lychee.html`<a><span title='Camera Date'>${build.iconic('camera-slr')}</span>${data.takedate}</a>`;
+	if (data.takedate !== '') html += lychee.html`<a><span title='Camera Date'>${build.iconic('camera-slr')}</span>${data.takedate}</a>`;
 	else html += lychee.html`<a>${data.sysdate}</a>`;
 
 	html += `</div>`;


### PR DESCRIPTION
This fixes a regression I've noticed where we no longer print the take date of photos underneath their names in the album view. This is because the server no longer sends the `cameraDate` field. We can rely on the `takedate` instead though.