### PR TITLE
chore(deps): use del instead of gulp-rimraf

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 let gulp = require('gulp'),
     plugins = require('gulp-load-plugins')(),
     cleanCSS = require('gulp-clean-css'),
+    del = require('del'),
     paths = {};
 
 /* Error Handler -------------------------------- */
@@ -387,9 +388,7 @@ gulp.task('leafletMarkerclusterSourceFiles--copy', function () {
 
 gulp.task('clean', function() {
 
-	return gulp.src('../dist/_*.*', { read: false })
-	           .pipe(plugins.rimraf({ force: true }))
-	           .on('error', catchError)
+    return del(['../dist/_*.*'], {force: true}).catch((error) => console.log(error))
 
 });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "gulp-concat": "^2.6.1",
     "gulp-inject": "^4.2.0",
     "gulp-load-plugins": "^1.5.0",
-    "gulp-rimraf": "^0.2.1",
     "gulp-sass": "^4.0.2",
     "gulp-uglify": "^3.0.2",
     "jquery": "^3.4.0",
@@ -42,5 +41,8 @@
     "scroll-lock": "^2.1.2",
     "spin.js": "^2.3.2",
     "uglify-js": "^3.7.2"
+  },
+  "devDependencies": {
+    "del": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Description

Use [`del`](https://www.npmjs.com/package/del) instead of [`gulp-rimraf`](https://www.npmjs.com/package/gulp-rimraf) when clean in the gulp task.

## Why

As `gulp-rimraf` owner favors of [gulp official delete file recipe](https://github.com/gulpjs/gulp/blob/1693a1127116a6804a892a4b931c232b1bec9162/docs/recipes/delete-files-folder.md).

> Deprecated in favor of https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md

And it is use [`del`](https://www.npmjs.com/package/del) package.

Thank you :)