### PR TITLE
chore: require nodejs v10.0.0 or later and cross build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
       dist: xenial #16.04
 
 node_js:
-  - "node"
+  - 10
+  - 12
+  - 14
 
 before_script:
   - npm install

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd Lychee-front
 
 First you have to install the following dependencies:
 
-- `node` [Node.js](http://nodejs.org) v5.7.0 or later
+- `node` [Node.js](http://nodejs.org) v10.0.0 or later
 - `npm` [Node Packaged Modules](https://www.npmjs.org)
 
 After [installing Node.js](http://nodejs.org) you can use the included `npm` package manager to download all dependencies:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "start": "gulp watch",
     "compile": "gulp"
   },
+  "engines": {
+    "node": ">= 10"
+  },
   "dependencies": {
     "babel-preset-env": "^1.7.0",
     "basicmodal": "github:LycheeOrg/basicmodal#master",


### PR DESCRIPTION
## Reason

Currently nodejs supports higher than `v10.x`

> [Release schedule](https://github.com/nodejs/Release/tree/23a3ffd4d289ad8d5e7c1b14f2a004a1cad78292)

## Changes

* Update README.md
* Add `engines` option in `package.json`
* Set nodejs cross-build on travis ci

---

Thank you :)