### PR TITLE
fix: 422 error when create new album in SmartAlbum

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -256,7 +256,7 @@ album.add = function (IDs = null, callback = null) {
 			parent_id: 0
 		};
 
-		if (visible.albums()) {
+		if (visible.albums() || album.isSmartID(album.json.id)) {
 			params.parent_id = 0;
 		} else if (visible.album()) {
 			params.parent_id = album.json.id;


### PR DESCRIPTION
## Description

Fix: https://github.com/LycheeOrg/Lychee/issues/658

## Changes

Set parent album to `0` when creating a new album in SmartAlbum.
I referred to the below comment.

>  https://github.com/LycheeOrg/Lychee/issues/658#issuecomment-657112143

---

Thank you :)