### PR TITLE
Fix unfocusable

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -282,7 +282,7 @@ header.setMode = function(mode) {
 			if (albumID==='s' || albumID==='f' || albumID==='r') {
 				$('#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album').hide();
 				$('.button_add, .header__divider', '.header__toolbar--album').show();
-				tabindex.makeFocusable($('.button_add, .header__divider', '.header__toolbar--album').show());
+				tabindex.makeFocusable($('.button_add, .header__divider', '.header__toolbar--album'));
 				tabindex.makeUnfocusable($('#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album'));
 			} else if (albumID==='0') {
 				$('#button_info_album, #button_visibility_album, #button_move_album').hide();

--- a/scripts/main/tabindex.js
+++ b/scripts/main/tabindex.js
@@ -10,6 +10,9 @@ let tabindex = {
 };
 
 tabindex.saveSettings = function(elem) {
+
+    if (!lychee.enable_tabindex) return;
+
     // Todo: Make shorter notation
     // Get all elements which have a tabindex
     let tmp = $(elem).find("[tabindex]");
@@ -39,6 +42,8 @@ tabindex.restoreSettings = function(elem) {
 }
 
 tabindex.makeUnfocusable = function(elem, saveFocusElement = false) {
+
+    if (!lychee.enable_tabindex) return;
 
     // Todo: Make shorter noation
     // Get all elements which have a tabindex


### PR DESCRIPTION
Fixes a bug introduced in #205.

The bug manifested itself as the search input field becoming permanently disabled after one switches to album view and then back to albums/public view.

The issue was that `tabindex.makeFocusable` is a noop if tabindex is not enabled, but an identical test was missing from `tabindex.makeUnfocusable`. Same with saveSettings/restoreSettings although I don't know if that could cause any real problems.

While looking for the bug I also spotted a copy-paste error that I fixed.