### PR TITLE
Restore enter actions in more input fields

### DIFF
--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -116,12 +116,12 @@ $(document).ready(function() {
 	Mousetrap.bindGlobal('enter', function() {
 		if (basicModal.visible()===true) {
 
-      // check if any of the input fields is focussed
-      // apply action, other do nothing
-      if($('.signIn > input').is(':focus')) {
-        basicModal.action();
-        return false;
-      }
+			// check if any of the input fields is focussed
+			// apply action, other do nothing
+			if($('.basicModal__content input').is(':focus')) {
+				basicModal.action();
+				return false;
+			}
 		} else if (visible.photo() && !lychee.header_auto_hide && ($('img#image').is(':focus') || $('img#livephoto').is(':focus') || ($(':focus').length === 0 ))) {
 			if (visible.header()) {
 				header.hide();
@@ -130,10 +130,16 @@ $(document).ready(function() {
 			}
 			return false;
 		}
-    $(':focus').each(function() {
-      $(this).click();
-    });
-		return false;
+		let clicked = false;
+		$(':focus').each(function() {
+			if (!$(this).is('input')) {
+				$(this).click();
+				clicked = true;
+			}
+		});
+		if (clicked) {
+			return false;
+		}
 	});
 
 


### PR DESCRIPTION
Restores some of the enter actions that were inadvertently disabled in #205.

In particular, restores enter in all basic modals, not just in the signin one. I did keep @tmp-hallenser's change of only applying it to modals with active input fields though. So the second enter in the advanced settings still won't work but that doesn't bother me.

The event is also bubbled up if nothing was clicked which restores the first enter in the advanced settings.

I also cleaned up the indentation while I was there :smiley:.