### PR TITLE
some dependencies move from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,17 +17,7 @@
     "node": ">= 10"
   },
   "dependencies": {
-    "babel-preset-env": "^1.7.0",
     "basicmodal": "github:LycheeOrg/basicmodal#master",
-    "gulp": "^4.0.0",
-    "gulp-autoprefixer": "^6.0.0",
-    "gulp-babel": "^6.1.2",
-    "gulp-clean-css": "^3.10.0",
-    "gulp-concat": "^2.6.1",
-    "gulp-inject": "^4.2.0",
-    "gulp-load-plugins": "^1.5.0",
-    "gulp-sass": "^4.0.2",
-    "gulp-uglify": "^3.0.2",
     "jquery": "^3.4.0",
     "justified-layout": "^2.1.1",
     "lazysizes": "^4.1.7",
@@ -38,14 +28,24 @@
     "livephotoskit": "^1.5.6",
     "mousetrap": "^1.6.0",
     "multiselect-two-sides": "^2.5.5",
-    "node-sass": "^4.13.0",
-    "npm": "^6.13.4",
     "require": "^2.4.20",
     "scroll-lock": "^2.1.2",
-    "spin.js": "^2.3.2",
-    "uglify-js": "^3.7.2"
+    "spin.js": "^2.3.2"
   },
   "devDependencies": {
-    "del": "^5.1.0"
+    "babel-preset-env": "^1.7.0",
+    "gulp": "^4.0.0",
+    "gulp-autoprefixer": "^6.0.0",
+    "gulp-babel": "^6.1.2",
+    "gulp-clean-css": "^3.10.0",
+    "gulp-concat": "^2.6.1",
+    "gulp-inject": "^4.2.0",
+    "gulp-load-plugins": "^1.5.0",
+    "gulp-sass": "^4.0.2",
+    "gulp-uglify": "^3.0.2",
+    "del": "^5.1.0",
+    "uglify-js": "^3.7.2",
+    "node-sass": "^4.13.0",
+    "npm": "^6.13.4"
   }
 }


### PR DESCRIPTION
## Description

Move some dependencies from `dependencies` to `devDependencies` in `package.json`

## Reason

The `devDependencies` are just for development dependency that like gulp (task runner), babel (transpiler), etc...
It is similar to `require` and `require-dev` relationship in `composer.json` for PHP.

IMHO, it is better to separate them for developers.

Thank you :)