### PR TITLE
Update README to remove ref to obsolete submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,11 @@ If you want to contribute and edit CSS or JS files, you need to rebuild Lychee. 
 # Clone Lychee
 git clone https://github.com/LycheeOrg/Lychee.git
 
-# Initialize the submodules (doc and frontend)
+# Initialize the frontend submodule
 git submodule init
 
-# Get the documentations
-git submodule update docs
-
 # Get the frontend
-git submodule update Lychee-front
+git submodule update
 
 # Go into the frontend
 cd Lychee-front


### PR DESCRIPTION
Looks like since the v4 the Lychee main repo doesn't include the docs a submodule, so no need to keep it in the install steps.