### PR TITLE
Various fixes

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1011,7 +1011,7 @@ album.delete = function (albumIDs) {
 				});
 			} else if (visible.album()) {
 				albums.refresh();
-				if (albumIDs.length === 1 && parseInt(album.getID()) === parseInt(albumIDs[0])) {
+				if (albumIDs.length === 1 && album.getID() == albumIDs[0]) {
 					lychee.goto(album.getParent());
 				} else {
 					albumIDs.forEach(function (id) {
@@ -1025,7 +1025,7 @@ album.delete = function (albumIDs) {
 		});
 	};
 
-	if (albumIDs.toString() === "0") {
+	if (albumIDs.toString() === "unsorted") {
 		action.title = lychee.locale["CLEAR_UNSORTED"];
 		cancel.title = lychee.locale["KEEP_UNSORTED"];
 

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -338,6 +338,11 @@ album.setShowTags = function (albumID) {
 	let oldShowTags = album.json.show_tags;
 
 	const action = function (data) {
+		if (!data.show_tags.trim()) {
+			basicModal.error("show_tags");
+			return;
+		}
+
 		let show_tags = data.show_tags;
 		basicModal.close();
 

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -238,6 +238,11 @@ album.add = function (IDs = null, callback = null) {
 
 		const isNumber = (n) => !isNaN(parseInt(n, 10)) && isFinite(n);
 
+		if (!data.title.trim()) {
+			basicModal.error("title");
+			return;
+		}
+
 		basicModal.close();
 
 		let params = {
@@ -284,6 +289,15 @@ album.add = function (IDs = null, callback = null) {
 
 album.addByTags = function () {
 	const action = function (data) {
+		if (!data.title.trim()) {
+			basicModal.error("title");
+			return;
+		}
+		if (!data.tags.trim()) {
+			basicModal.error("tags");
+			return;
+		}
+
 		basicModal.close();
 
 		let params = {
@@ -382,6 +396,11 @@ album.setTitle = function (albumIDs) {
 	}
 
 	const action = function (data) {
+		if (!data.title.trim()) {
+			basicModal.error("title");
+			return;
+		}
+
 		basicModal.close();
 
 		let newTitle = data.title;

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -297,21 +297,26 @@ header.setMode = function (mode) {
 			}
 
 			if (albumID === "starred" || albumID === "public" || albumID === "recent") {
-				$("#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album").hide();
-				$(".button_add, .header__divider", ".header__toolbar--album").show();
-				tabindex.makeFocusable($(".button_add, .header__divider", ".header__toolbar--album"));
-				tabindex.makeUnfocusable($("#button_info_album, #button_trash_album, #button_visibility_album, #button_move_album"));
+				$("#button_nsfw_album, #button_info_album, #button_trash_album, #button_visibility_album, #button_move_album").hide();
+				if (album.isUploadable()) {
+					$(".button_add, .header__divider", ".header__toolbar--album").show();
+					tabindex.makeFocusable($(".button_add, .header__divider", ".header__toolbar--album"));
+				} else {
+					$(".button_add, .header__divider", ".header__toolbar--album").hide();
+					tabindex.makeUnfocusable($(".button_add, .header__divider", ".header__toolbar--album"));
+				}
+				tabindex.makeUnfocusable($("#button_nsfw_album, #button_info_album, #button_trash_album, #button_visibility_album, #button_move_album"));
 			} else if (albumID === "unsorted") {
-				$("#button_info_album, #button_visibility_album, #button_move_album").hide();
+				$("#button_nsfw_album, #button_info_album, #button_visibility_album, #button_move_album").hide();
 				$("#button_trash_album, .button_add, .header__divider", ".header__toolbar--album").show();
 				tabindex.makeFocusable($("#button_trash_album, .button_add, .header__divider", ".header__toolbar--album"));
-				tabindex.makeUnfocusable($("#button_info_album, #button_visibility_album, #button_move_album"));
+				tabindex.makeUnfocusable($("#button_nsfw_album, #button_info_album, #button_visibility_album, #button_move_album"));
 			} else if (album.isTagAlbum()) {
 				$("#button_info_album").show();
-				$("#button_move_album").hide();
+				$("#button_nsfw_album, #button_move_album").hide();
 				$(".button_add, .header__divider", ".header__toolbar--album").hide();
 				tabindex.makeFocusable($("#button_info_album"));
-				tabindex.makeUnfocusable($("#button_move_album"));
+				tabindex.makeUnfocusable($("#button_nsfw_album, #button_move_album"));
 				tabindex.makeUnfocusable($(".button_add, .header__divider", ".header__toolbar--album"));
 				if (album.isUploadable()) {
 					$("#button_visibility_album, #button_trash_album").show();
@@ -330,7 +335,7 @@ header.setMode = function (mode) {
 					).show();
 					tabindex.makeFocusable(
 						$(
-							"#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider",
+							"#button_nsfw_album, #button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider",
 							".header__toolbar--album"
 						)
 					);
@@ -341,7 +346,7 @@ header.setMode = function (mode) {
 					).hide();
 					tabindex.makeUnfocusable(
 						$(
-							"#button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider",
+							"#button_nsfw_album, #button_trash_album, #button_move_album, #button_visibility_album, .button_add, .header__divider",
 							".header__toolbar--album"
 						)
 					);

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -305,7 +305,9 @@ header.setMode = function (mode) {
 					$(".button_add, .header__divider", ".header__toolbar--album").hide();
 					tabindex.makeUnfocusable($(".button_add, .header__divider", ".header__toolbar--album"));
 				}
-				tabindex.makeUnfocusable($("#button_nsfw_album, #button_info_album, #button_trash_album, #button_visibility_album, #button_move_album"));
+				tabindex.makeUnfocusable(
+					$("#button_nsfw_album, #button_info_album, #button_trash_album, #button_visibility_album, #button_move_album")
+				);
 			} else if (albumID === "unsorted") {
 				$("#button_nsfw_album, #button_info_album, #button_visibility_album, #button_move_album").hide();
 				$("#button_trash_album, .button_add, .header__divider", ".header__toolbar--album").show();

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -318,6 +318,15 @@ lychee.login = function (data) {
 	let username = data.username;
 	let password = data.password;
 
+	if (!username.trim()) {
+		basicModal.error("username");
+		return;
+	}
+	if (!password.trim()) {
+		basicModal.error("password");
+		return;
+	}
+
 	let params = {
 		username,
 		password,

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -820,7 +820,17 @@ photo.setTags = function (photoIDs, tags) {
 	};
 
 	api.post("Photo::setTags", params, function (data) {
-		if (data !== true) lychee.error(null, params, data);
+		if (data !== true) {
+			lychee.error(null, params, data);
+		} else if (albums.json && albums.json.smartalbums) {
+			$.each(Object.entries(albums.json.smartalbums), function() {
+				if (this.length == 2 && this[1]["tag_album"] === "1") {
+					// If we have any tag albums, force a refresh.
+					albums.refresh();
+					return false;
+				}
+			});
+		}
 	});
 };
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -823,7 +823,7 @@ photo.setTags = function (photoIDs, tags) {
 		if (data !== true) {
 			lychee.error(null, params, data);
 		} else if (albums.json && albums.json.smartalbums) {
-			$.each(Object.entries(albums.json.smartalbums), function() {
+			$.each(Object.entries(albums.json.smartalbums), function () {
 				if (this.length == 2 && this[1]["tag_album"] === "1") {
 					// If we have any tag albums, force a refresh.
 					albums.refresh();

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -381,6 +381,11 @@ photo.setTitle = function (photoIDs) {
 	}
 
 	const action = function (data) {
+		if (!data.title.trim()) {
+			basicModal.error("title");
+			return;
+		}
+
 		basicModal.close();
 
 		let newTitle = data.title;

--- a/scripts/main/settings.js
+++ b/scripts/main/settings.js
@@ -146,12 +146,12 @@ settings.createLogin = function () {
 		let password = data.password;
 		let confirm = data.confirm;
 
-		if (username.length < 1) {
+		if (!username.trim()) {
 			basicModal.error("username");
 			return false;
 		}
 
-		if (password.length < 1) {
+		if (!password.trim()) {
 			basicModal.error("password");
 			return false;
 		}

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -234,7 +234,7 @@ upload.start = {
 		const action = function (data) {
 			let files = [];
 
-			if (data.link && data.link.length > 3) {
+			if (data.link && data.link.trim().length > 3) {
 				basicModal.close();
 
 				files[0] = {
@@ -300,6 +300,11 @@ upload.start = {
 		if (albumID === false) albumID = 0;
 
 		const action = function (data) {
+			if (!data.path.trim()) {
+				basicModal.error("path");
+				return;
+			}
+
 			let files = [];
 
 			files[0] = {


### PR DESCRIPTION
Assorted minor fixes:

* Don't show the "+" menu entry for smart albums in public mode.
* Clean up the NSFW button while fixing the above.
* Deleting the (content of) the Unsorted album was broken after the rename from `0` to `unsorted`.
* Many text fields didn't check for empty content before sending it to the server, resulting in ugly server errors. Even basic things like the login dialog. Whitespace-only entries generally trigger the same issue, hence the `trim` test.
* After adding/deleting/changing tags of photos, refresh the albums view if there are any tag albums (since they could be affected).