### PR TITLE
Display takedate for photos and albums

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -73,7 +73,6 @@ build.getAlbumThumb = function (data) {
 };
 
 build.album = function (data, disabled = false) {
-	let sortingAlbums = [];
 	let subtitle = data.sysdate;
 
 	// check setting album_subtitle_type:
@@ -98,7 +97,7 @@ build.album = function (data, disabled = false) {
 		case "oldstyle":
 		default:
 			if (lychee.sortingAlbums !== "" && data.min_takestamp && data.max_takestamp) {
-				sortingAlbums = lychee.sortingAlbums.replace("ORDER BY ", "").split(" ");
+				let sortingAlbums = lychee.sortingAlbums.replace("ORDER BY ", "").split(" ");
 				if (sortingAlbums[0] === "max_takestamp" || sortingAlbums[0] === "min_takestamp") {
 					if (data.min_takestamp !== "" && data.max_takestamp !== "") {
 						subtitle = data.min_takestamp === data.max_takestamp ? data.max_takestamp : data.min_takestamp + " - " + data.max_takestamp;
@@ -276,7 +275,7 @@ build.check_overlay_type = function (data, overlay_type, next = false) {
 	let idx = types.indexOf(overlay_type);
 	if (idx < 0) return "none";
 	if (next) idx++;
-	let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
+	let exifHash = data.make + data.model + data.shutter + data.iso + (data.type.indexOf("video") !== 0 ? data.aperture + data.focal : "");
 
 	for (let i = 0; i < types.length; i++) {
 		let type = types[(idx + i) % types.length];
@@ -311,7 +310,7 @@ build.overlay_image = function (data) {
 				}
 				if (data.focal && data.focal !== "") {
 					if (overlay !== "") overlay += "<br>";
-					overlay += data.focal + (data.lens && data.lens !== "" ? "(" + data.lens + ")" : "");
+					overlay += data.focal + (data.lens && data.lens !== "" ? " (" + data.lens + ")" : "");
 				}
 			}
 			break;
@@ -392,9 +391,9 @@ build.imageview = function (data, visibleControls, autoplay) {
 		}
 
 		html += lychee.html`${img}`;
-
-		if (lychee.image_overlay) html += build.overlay_image(data);
 	}
+
+	if (lychee.image_overlay) html += build.overlay_image(data);
 
 	html += `
 			<div class='arrow_wrapper arrow_wrapper--previous'><a id='previous'>${build.iconic("caret-left")}</a></div>

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -256,9 +256,11 @@ build.overlay_image = function (data) {
 				<div id="image_overlay">
 				<h1>$${data.title}</h1>
 				`;
-	if( data.takedate && data.takedate !== '') html += `<p>${data.takedate}</p>
+	if (data.takedate && data.takedate !== "")
+		html += `<p>${data.takedate}</p>
 				`;
-	else html += `<p>${data.sysdate}</p>
+	else
+		html += `<p>${data.sysdate}</p>
 				`;
 
 	if (type && type === "desc" && data.description !== "") {
@@ -273,25 +275,26 @@ build.overlay_image = function (data) {
 		let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
 		if (exifHash !== "") {
 			let takedata = ``;
-			if (data.shutter && data.shutter !== "" ) takedata = data.shutter.replace("s", "sec");
+			if (data.shutter && data.shutter !== "") takedata = data.shutter.replace("s", "sec");
 			if (data.aperture && data.aperture !== "") {
 				if (takedata !== "") takedata += " at ";
 				takedata += data.aperture.replace("f/", "&fnof; / ");
 			}
 			if (data.iso && data.iso !== "") {
 				if (takedata !== "") takedata += ", ";
-					takedata += lychee.locale["PHOTO_ISO"] + " " + data.iso;
-				}
-				if (data.focal && data.focal !== "") {
-					if (takedata !== "") takedata += "<br>";
-					takedata += data.lens && data.lens !== "" ? "(" + data.lens + ")" : "";
-				}
-				if (takedata !== "") html += `
+				takedata += lychee.locale["PHOTO_ISO"] + " " + data.iso;
+			}
+			if (data.focal && data.focal !== "") {
+				if (takedata !== "") takedata += "<br>";
+				takedata += data.lens && data.lens !== "" ? "(" + data.lens + ")" : "";
+			}
+			if (takedata !== "")
+				html += `
 					<p>${takedata}</p>
 					`;
-			}
-        }
-       html += `</div>
+		}
+	}
+	html += `</div>
 			`;
 
 	return html;

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -74,6 +74,7 @@ build.getAlbumThumb = function (data) {
 
 build.album = function (data, disabled = false) {
 	let sortingAlbums = [];
+	let subtitle = data.sysdate;
 
 	// check setting album_subtitle_type:
 	// takedate: date range (min/max_takedate from EXIF; if missing defaults to creation)
@@ -91,12 +92,11 @@ build.album = function (data, disabled = false) {
 				subtitle = `<span title='Camera Date'>${build.iconic("camera-slr")}</span>${subtitle}`;
 				break;
 			}
+		// fall through
 		case "creation":
-			subtitle = data.sysdate;
 			break;
 		case "oldstyle":
 		default:
-			subtitle = data.sysdate;
 			if (lychee.sortingAlbums !== "" && data.min_takestamp && data.max_takestamp) {
 				sortingAlbums = lychee.sortingAlbums.replace("ORDER BY ", "").split(" ");
 				if (sortingAlbums[0] === "max_takestamp" || sortingAlbums[0] === "min_takestamp") {
@@ -126,7 +126,7 @@ build.album = function (data, disabled = false) {
 			`;
 
 	if (album.isUploadable() && !disabled) {
-		isCover = album.json && album.json.cover_id && data.thumb.id === album.json.cover_id;
+		let isCover = album.json && album.json.cover_id && data.thumb.id === album.json.cover_id;
 		html += lychee.html`
 				<div class='badges'>
 					<a class='badge ${data.nsfw === "1" ? "badge--nsfw" : ""} icn-warning'>${build.iconic("warning")}</a>
@@ -276,11 +276,11 @@ build.check_overlay_type = function (data, overlay_type, next = false) {
 	let idx = types.indexOf(overlay_type);
 	if (idx < 0) return "none";
 	if (next) idx++;
-	for (i = 0; i < types.length; i++) {
+	for (let i = 0; i < types.length; i++) {
 		let type = types[(idx + i) % types.length];
 		switch (type) {
 			case "desc":
-				if (data.description && data.description != "") return type;
+				if (data.description && data.description !== "") return type;
 				continue;
 			case "date":
 				return type;
@@ -293,6 +293,8 @@ build.check_overlay_type = function (data, overlay_type, next = false) {
 				return "none";
 		}
 	}
+	// effectively unreachable
+	return "none";
 };
 
 build.overlay_image = function (data) {

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -276,25 +276,14 @@ build.check_overlay_type = function (data, overlay_type, next = false) {
 	let idx = types.indexOf(overlay_type);
 	if (idx < 0) return "none";
 	if (next) idx++;
+	let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
+
 	for (let i = 0; i < types.length; i++) {
 		let type = types[(idx + i) % types.length];
-		switch (type) {
-			case "desc":
-				if (data.description && data.description !== "") return type;
-				continue;
-			case "date":
-				return type;
-			case "exif":
-				let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
-				if (exifHash !== "") return type;
-				continue;
-			default:
-				// should not happen
-				return "none";
-		}
+		if (type === "desc" && data.description && data.description !== "") return type;
+		if (type === "date") return type;
+		if (type === "exif" && exifHash !== "") return type;
 	}
-	// effectively unreachable
-	return "none";
 };
 
 build.overlay_image = function (data) {
@@ -328,6 +317,7 @@ build.overlay_image = function (data) {
 			break;
 		default:
 	}
+
 	return (
 		lychee.html`
 		<div id="image_overlay">

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -188,7 +188,7 @@ lychee.init = function () {
 
 			lychee.sortingPhotos = data.config.sorting_Photos || data.config.sortingPhotos || "";
 			lychee.sortingAlbums = data.config.sorting_Albums || data.config.sortingAlbums || "";
-			lychee.album_subtitle_type = data.config.album_subtitle_type || "";
+			lychee.album_subtitle_type = data.config.album_subtitle_type || "oldstyle";
 			lychee.dropboxKey = data.config.dropbox_key || data.config.dropboxKey || "";
 			lychee.location = data.config.location || "";
 			lychee.checkForUpdates = data.config.check_for_updates || data.config.checkForUpdates || "1";
@@ -268,6 +268,7 @@ lychee.init = function () {
 			// TODO remove sortingPhoto once the v4 is out
 			lychee.sortingPhotos = data.config.sorting_Photos || data.config.sortingPhotos || "";
 			lychee.sortingAlbums = data.config.sorting_Albums || data.config.sortingAlbums || "";
+			lychee.album_subtitle_type = data.config.album_subtitle_type || "oldstyle";
 			lychee.checkForUpdates = data.config.check_for_updates || data.config.checkForUpdates || "1";
 			lychee.layout = data.config.layout || "1";
 			lychee.public_search = (data.config.public_search && data.config.public_search === "1") || false;

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -47,6 +47,8 @@ let lychee = {
 	nsfw_blur: false,
 	nsfw_warning: false,
 
+	album_subtitle_type: "oldstyle",
+
 	// this is device specific config, in this case default is Desktop.
 	header_auto_hide: true,
 	active_focus_on_page_load: false,
@@ -186,6 +188,7 @@ lychee.init = function () {
 
 			lychee.sortingPhotos = data.config.sorting_Photos || data.config.sortingPhotos || "";
 			lychee.sortingAlbums = data.config.sorting_Albums || data.config.sortingAlbums || "";
+			lychee.album_subtitle_type = data.config.album_subtitle_type || "";
 			lychee.dropboxKey = data.config.dropbox_key || data.config.dropboxKey || "";
 			lychee.location = data.config.location || "";
 			lychee.checkForUpdates = data.config.check_for_updates || data.config.checkForUpdates || "1";

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -100,29 +100,14 @@ photo.isLivePhotoPlaying = function () {
 
 photo.update_overlay_type = function () {
 	// Only run if the overlay is showing
-	if (!lychee.image_overlay) {
-		return false;
-	} else {
-		// console.log('Current ' + lychee.image_overlay_type);
-		let types = ["exif", "desc", "takedate"];
+	if (!lychee.image_overlay) return false;
 
-		let i = types.indexOf(lychee.image_overlay_type);
-		let j = (i + 1) % types.length;
-		let cont = true;
-		while (i !== j && cont) {
-			if (types[j] === "desc" && photo.hasDesc()) cont = false;
-			else if (types[j] === "takedate" && photo.hasTakedate()) cont = false;
-			else if (types[j] === "exif" && photo.hasExif()) cont = false;
-			else j = (j + 1) % types.length;
-		}
-
-		if (i !== j) {
-			lychee.image_overlay_type = types[j];
-			$("#image_overlay").remove();
-			lychee.imageview.append(build.overlay_image(photo.json));
-		} else {
-			// console.log('no other data found, displaying ' + types[j]);
-		}
+	let oldtype = build.check_overlay_type(photo.json, lychee.image_overlay_type);
+	let newtype = build.check_overlay_type(photo.json, oldtype, true);
+	if (oldtype != newtype) {
+		lychee.image_overlay_type = newtype;
+		$("#image_overlay").remove();
+		lychee.imageview.append(build.overlay_image(photo.json));
 	}
 };
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -104,7 +104,7 @@ photo.update_overlay_type = function () {
 
 	let oldtype = build.check_overlay_type(photo.json, lychee.image_overlay_type);
 	let newtype = build.check_overlay_type(photo.json, oldtype, true);
-	if (oldtype != newtype) {
+	if (oldtype !== newtype) {
 		lychee.image_overlay_type = newtype;
 		$("#image_overlay").remove();
 		lychee.imageview.append(build.overlay_image(photo.json));

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -186,6 +186,7 @@
 		color: #ccc;
 		text-shadow: 0 1px 3px black(0.4);
 	}
+	.album .overlay a .iconic,
 	.photo .overlay a .iconic {
 		fill: #ccc;
 		margin: 0 5px 0 0;

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -138,6 +138,13 @@
 			font-size: 20px;
 			line-height: 24px;
 		}
+
+		a .iconic {
+			fill: #fff;
+			margin: 0 5px 0 0;
+			width: 14px;
+			height: 14px;
+		}
 	}
 
 	&.full #image_overlay h1 {


### PR DESCRIPTION
This pull request addresses a few minor issues with the front-end:

1. When sorting albums by anything but timestamps (e.g. by title), the date below the title shows the import date. Regardless of sorting preferences it seems preferable to display the date range of photos in the album (`build.album`, l.84-89).
2. Photo views show no overlay if EXIF info is missing. In these cases the overlay should at least show the title and the creation/upload date (`build.overlay_image`, l.253ff)
3. For media files with corrupt/incomplete EXIF information a few checks are performed while compiling the overlay to prevent empty fields (`build.overlay_image`, l.275ff)