### PR TITLE
frontend code for disabling direction display on embedded map

### DIFF
--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -200,6 +200,7 @@ lychee.init = function () {
 			lychee.image_overlay_type_default = lychee.image_overlay_type;
 			lychee.map_display = (data.config.map_display && data.config.map_display === "1") || false;
 			lychee.map_display_public = (data.config.map_display_public && data.config.map_display_public === "1") || false;
+			lychee.map_display_direction = (data.config.map_display_direction && data.config.map_display_direction === "1") || false;
 			lychee.map_provider = !data.config.map_provider ? "Wikimedia" : data.config.map_provider;
 			lychee.map_include_subalbums = (data.config.map_include_subalbums && data.config.map_include_subalbums === "1") || false;
 			lychee.location_decoding = (data.config.location_decoding && data.config.location_decoding === "1") || false;
@@ -274,6 +275,7 @@ lychee.init = function () {
 			lychee.image_overlay_type_default = lychee.image_overlay_type;
 			lychee.map_display = (data.config.map_display && data.config.map_display === "1") || false;
 			lychee.map_display_public = (data.config.map_display_public && data.config.map_display_public === "1") || false;
+			lychee.map_display_direction = (data.config.map_display_direction && data.config.map_display_direction === "1") || false;
 			lychee.map_provider = !data.config.map_provider ? "Wikimedia" : data.config.map_provider;
 			lychee.map_include_subalbums = (data.config.map_include_subalbums && data.config.map_include_subalbums === "1") || false;
 			lychee.location_show = (data.config.location_show && data.config.location_show === "1") || false;

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -30,6 +30,7 @@ let lychee = {
 	image_overlay_type_default: "exif", // image overlay type default type
 	map_display: false, // display photo coordinates on map
 	map_display_public: false, // display photos of public album on map (user not logged in)
+	map_display_direction: true, // use the GPS direction data on displayed maps
 	map_provider: "Wikimedia", // Provider of OSM Tiles
 	map_include_subalbums: false, // include photos of subalbums on map
 	location_decoding: false, // retrieve location name from GPS data

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -788,7 +788,7 @@ view.photo = {
 				attribution: map_provider_layer_attribution[lychee.map_provider].attribution,
 			}).addTo(mymap);
 
-			if (!photo.json.imgDirection || photo.json.imgDirection === "") {
+			if (!lychee.map_display_direction || !photo.json.imgDirection || photo.json.imgDirection === "") {
 				// Add Marker to map, direction is not set
 				L.marker([photo.json.latitude, photo.json.longitude]).addTo(mymap);
 			} else {


### PR DESCRIPTION
This is the frontend code addressing LycheeOrg/Lychee#886, reading the configuration object and not displaying the directional cone if the setting is off. 