### PR TITLE
Fix rotation

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1224,6 +1224,34 @@ album.isUploadable = function () {
 	return album.json.owner === lychee.username;
 };
 
+album.updatePhoto = function (data) {
+	if (album.json) {
+		$.each(album.json.photos, function () {
+			if (this.id == data.id) {
+				this.width = data.width;
+				this.height = data.height;
+				this.small = data.small;
+				this.small_dim = data.small_dim;
+				this.small2x = data.small2x;
+				this.small2x_dim = data.small2x_dim;
+				this.medium = data.medium;
+				this.medium_dim = data.medium_dim;
+				this.medium2x = data.medium2x;
+				this.medium2x_dim = data.medium2x_dim;
+				this.thumbUrl = data.thumbUrl;
+				this.thumb2x = data.thumb2x;
+				this.url = data.url;
+				this.size = data.size;
+
+				view.album.content.updatePhoto(this);
+				albums.refresh();
+
+				return false;
+			}
+		});
+	}
+};
+
 album.reload = function () {
 	let albumID = album.getID();
 

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1227,7 +1227,7 @@ album.isUploadable = function () {
 album.updatePhoto = function (data) {
 	if (album.json) {
 		$.each(album.json.photos, function () {
-			if (this.id == data.id) {
+			if (this.id === data.id) {
 				this.width = data.width;
 				this.height = data.height;
 				this.small = data.small;
@@ -1248,6 +1248,7 @@ album.updatePhoto = function (data) {
 
 				return false;
 			}
+			return true;
 		});
 	}
 };

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -343,7 +343,7 @@ photo.delete = function (photoIDs) {
 		action.title = lychee.locale["PHOTO_DELETE"];
 		cancel.title = lychee.locale["PHOTO_KEEP"];
 
-		msg = lychee.html`<p>${lychee.locale["PHOTO_DELETE_1"]} '${photoTitle}' ${lychee.locale["PHOTO_DELETE_2"]}</p>`;
+		msg = lychee.html`<p>${lychee.locale["PHOTO_DELETE_1"]} '${photoTitle}'${lychee.locale["PHOTO_DELETE_2"]}</p>`;
 	} else {
 		action.title = lychee.locale["PHOTO_DELETE"];
 		cancel.title = lychee.locale["PHOTO_KEEP"];

--- a/scripts/main/photoeditor.js
+++ b/scripts/main/photoeditor.js
@@ -5,14 +5,6 @@
 photoeditor = {};
 
 photoeditor.rotate = function (photoID, direction) {
-	var swapDims = function (d) {
-		let p = d.indexOf("x");
-		if (p !== -1) {
-			return d.substr(0, p) + "x" + d.substr(p + 1);
-		}
-		return d;
-	};
-
 	if (!photoID) return false;
 	if (!direction) return false;
 
@@ -22,39 +14,29 @@ photoeditor.rotate = function (photoID, direction) {
 	};
 
 	api.post("PhotoEditor::rotate", params, function (data) {
-		if (data !== true) {
+		if (data === false) {
 			lychee.error(null, params, data);
 		} else {
-			let mr = "?" + Math.random();
-			let sel_big = "img#image";
-			let sel_thumb = "div[data-id=" + photoID + "] > span > img";
-			let sel_div = "div[data-id=" + photoID + "]";
-			$(sel_big).prop("src", $(sel_big).attr("src") + mr);
-			$(sel_big).prop("srcset", $(sel_big).attr("src"));
-			$(sel_thumb).prop("src", $(sel_thumb).attr("src") + mr);
-			$(sel_thumb).prop("srcset", $(sel_thumb).attr("src"));
-			var arrayLength = album.json.photos.length;
-			for (var i = 0; i < arrayLength; i++) {
-				if (album.json.photos[i].id === photoID) {
-					let w = album.json.photos[i].width;
-					let h = album.json.photos[i].height;
-					album.json.photos[i].height = w;
-					album.json.photos[i].width = h;
-					album.json.photos[i].small += mr;
-					album.json.photos[i].small_dim = swapDims(album.json.photos[i].small_dim);
-					album.json.photos[i].small2x += mr;
-					album.json.photos[i].small2x_dim = swapDims(album.json.photos[i].small2x_dim);
-					album.json.photos[i].medium += mr;
-					album.json.photos[i].medium_dim = swapDims(album.json.photos[i].medium_dim);
-					album.json.photos[i].medium2x += mr;
-					album.json.photos[i].medium2x_dim = swapDims(album.json.photos[i].medium2x_dim);
-					album.json.photos[i].thumb2x += mr;
-					album.json.photos[i].thumbUrl += mr;
-					album.json.photos[i].url += mr;
-					view.album.content.justify();
-					break;
-				}
+			photo.json = data;
+			photo.json.original_album = photo.json.album;
+			if (album.json) {
+				photo.json.album = album.json.id;
 			}
+
+			image = $("img#image");
+			if (photo.json.hasOwnProperty("medium2x") && photo.json.medium2x !== "") {
+				image.prop(
+					"srcset",
+					`${photo.json.medium} ${parseInt(photo.json.medium_dim, 10)}w, ${photo.json.medium2x} ${parseInt(photo.json.medium2x_dim, 10)}w`
+				);
+			} else {
+				image.prop("srcset", "");
+			}
+			image.prop("src", photo.json.medium !== "" ? photo.json.medium : photo.json.url);
+			view.photo.onresize();
+			view.photo.sidebar();
+
+			album.updatePhoto(data);
 		}
 	});
 };

--- a/scripts/main/photoeditor.js
+++ b/scripts/main/photoeditor.js
@@ -23,7 +23,7 @@ photoeditor.rotate = function (photoID, direction) {
 				photo.json.album = album.json.id;
 			}
 
-			image = $("img#image");
+			let image = $("img#image");
 			if (photo.json.hasOwnProperty("medium2x") && photo.json.medium2x !== "") {
 				image.prop(
 					"srcset",

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -316,7 +316,7 @@ view.album = {
 					if (data.hasOwnProperty("medium2x") && data.medium2x !== "") {
 						srcset = `${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w`;
 					}
-				} else if (!data.type || data.type.indexOf("video") != 0) {
+				} else if (!data.type || data.type.indexOf("video") !== 0) {
 					src = data.url;
 				} else {
 					src = data.thumbUrl;
@@ -847,7 +847,7 @@ view.photo = {
 
 	header: function () {
 		if (
-			(photo.json.type && (photo.json.type.indexOf("video") == 0 || photo.json.type == "raw")) ||
+			(photo.json.type && (photo.json.type.indexOf("video") === 0 || photo.json.type === "raw")) ||
 			(photo.json.livePhotoUrl !== "" && photo.json.livePhotoUrl !== null)
 		) {
 			$("#button_rotate_cwise, #button_rotate_ccwise").hide();

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -295,6 +295,45 @@ view.album = {
 			}
 		},
 
+		updatePhoto: function (data) {
+			let src,
+				srcset = "";
+
+			// This mimicks the structure of build.photo
+			if (lychee.layout === "0") {
+				src = data.thumbUrl;
+				if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+					srcset = `${data.thumb2x} 2x`;
+				}
+			} else {
+				if (data.small !== "") {
+					src = data.small;
+					if (data.hasOwnProperty("small2x") && data.small2x !== "") {
+						srcset = `${data.small} ${parseInt(data.small_dim, 10)}w, ${data.small2x} ${parseInt(data.small2x_dim, 10)}w`;
+					}
+				} else if (data.medium !== "") {
+					src = data.medium;
+					if (data.hasOwnProperty("medium2x") && data.medium2x !== "") {
+						srcset = `${data.medium} ${parseInt(data.medium_dim, 10)}w, ${data.medium2x} ${parseInt(data.medium2x_dim, 10)}w`;
+					}
+				} else if (!data.type || data.type.indexOf("video") != 0) {
+					src = data.url;
+				} else {
+					src = data.thumbUrl;
+					if (data.hasOwnProperty("thumb2x") && data.thumb2x !== "") {
+						srcset = `${data.thumbUrl} 200w, ${data.thumb2x} 400w`;
+					}
+				}
+			}
+
+			$('.photo[data-id="' + data.id + '"] > span.thumbimg > img')
+				.attr("data-src", src)
+				.attr("data-srcset", srcset)
+				.addClass("lazyload");
+
+			view.album.content.justify();
+		},
+
 		delete: function (photoID, justify = false) {
 			$('.photo[data-id="' + photoID + '"]')
 				.css("opacity", 0)
@@ -561,6 +600,7 @@ view.photo = {
 		view.photo.title();
 		view.photo.star();
 		view.photo.public();
+		view.photo.header();
 		view.photo.photo(autoplay);
 
 		photo.json.init = 1;
@@ -802,6 +842,17 @@ view.photo = {
 				let marker = L.marker([photo.json.latitude, photo.json.longitude], { icon: viewDirectionIcon }).addTo(mymap);
 				marker.setRotationAngle(photo.json.imgDirection);
 			}
+		}
+	},
+
+	header: function () {
+		if (
+			(photo.json.type && (photo.json.type.indexOf("video") == 0 || photo.json.type == "raw")) ||
+			(photo.json.livePhotoUrl !== "" && photo.json.livePhotoUrl !== null)
+		) {
+			$("#button_rotate_cwise, #button_rotate_ccwise").hide();
+		} else {
+			$("#button_rotate_cwise, #button_rotate_ccwise").show();
 		}
 	},
 


### PR DESCRIPTION
This fixes image rotation (https://github.com/LycheeOrg/Lychee/issues/741).

The main fixes are on the server side. The front end changes do the following:
* Work with the new server rotation API that returns a full updated photo object rather than just `true`.
* Correctly handle the "2x" cases.
* Handle updates to album thumbs.
* Hide the rotation buttons for unsupported photo types.
* Update metadata in the sidebar.

There's also an unrelated small fix to the photo delete confirmation dialog removing a spurious space.