### PR TITLE
Support upload_processing_limit

### DIFF
--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -50,7 +50,7 @@ let lychee = {
 
 	album_subtitle_type: "oldstyle",
 
-	upload_processing_limit: 4,
+	upload_processing_limit: 2,
 
 	// this is device specific config, in this case default is Desktop.
 	header_auto_hide: true,
@@ -252,7 +252,7 @@ lychee.init = function () {
 			lychee.admin = !lychee.api_V2;
 			lychee.nsfw_visible_saved = lychee.nsfw_visible;
 
-			lychee.upload_processing_limit = parseInt(data.config.upload_processing_limit);
+			lychee.upload_processing_limit = parseInt(data.config.upload_processing_limit) || 4;
 
 			// leftMenu
 			leftMenu.build();

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -50,6 +50,8 @@ let lychee = {
 
 	album_subtitle_type: "oldstyle",
 
+	upload_processing_limit: 4,
+
 	// this is device specific config, in this case default is Desktop.
 	header_auto_hide: true,
 	active_focus_on_page_load: false,
@@ -249,6 +251,8 @@ lychee.init = function () {
 			lychee.upload = !lychee.api_V2;
 			lychee.admin = !lychee.api_V2;
 			lychee.nsfw_visible_saved = lychee.nsfw_visible;
+
+			lychee.upload_processing_limit = parseInt(data.config.upload_processing_limit);
 
 			// leftMenu
 			leftMenu.build();

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -36,13 +36,15 @@ upload.start = {
 		let albumID = album.getID();
 		let error = false;
 		let warning = false;
+		let processing_count = 0;
+		let next_upload = 0;
+		let currently_uploading = false;
 
-		const process = function (_files, file) {
+		const process = function (file_num) {
 			let formData = new FormData();
 			let xhr = new XMLHttpRequest();
 			let pre_progress = 0;
 			let progress = 0;
-			let next_file_started = false;
 
 			const finish = function () {
 				window.onbeforeunload = null;
@@ -71,7 +73,7 @@ upload.start = {
 
 			formData.append("function", "Photo::add");
 			formData.append("albumID", albumID);
-			formData.append(0, file);
+			formData.append(0, files[file_num]);
 
 			var api_url = api.get_url("Photo::add");
 
@@ -79,7 +81,6 @@ upload.start = {
 
 			xhr.onload = function () {
 				let data = null;
-				let wait = false;
 				let errorText = "";
 
 				const isNumber = (n) => !isNaN(parseFloat(n)) && isFinite(n);
@@ -100,12 +101,10 @@ upload.start = {
 					data = "";
 				}
 
-				file.ready = true;
-
 				// Set status
 				if (xhr.status === 200 && isNumber(data)) {
 					// Success
-					$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status")
+					$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status")
 						.html(lychee.locale["UPLOAD_FINISHED"])
 						.addClass("success");
 				} else {
@@ -123,7 +122,7 @@ upload.start = {
 						error = true;
 
 						// Error Status
-						$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status")
+						$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status")
 							.html(lychee.locale["UPLOAD_FAILED"])
 							.addClass("error");
 
@@ -134,7 +133,7 @@ upload.start = {
 						warning = true;
 
 						// Warning Status
-						$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status")
+						$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status")
 							.html(lychee.locale["UPLOAD_SKIPPED"])
 							.addClass("warning");
 
@@ -145,7 +144,7 @@ upload.start = {
 						error = true;
 
 						// Error Status
-						$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status")
+						$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status")
 							.html(lychee.locale["UPLOAD_FAILED"])
 							.addClass("error");
 
@@ -153,21 +152,24 @@ upload.start = {
 						lychee.error(lychee.locale["UPLOAD_ERROR_UNKNOWN"], xhr, data);
 					}
 
-					$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") p.notice")
+					$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") p.notice")
 						.html(errorText)
 						.show();
 				}
 
-				// Check if there are file which are not finished
-				for (let i = 0; i < _files.length; i++) {
-					if (_files[i].ready === false) {
-						wait = true;
-						break;
-					}
+				processing_count--;
+
+				// Upload next file
+				if (!currently_uploading &&
+					(processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) &&
+					next_upload < files.length) {
+					process(next_upload++);
 				}
 
 				// Finish upload when all files are finished
-				if (wait === false) finish();
+				if (!currently_uploading && processing_count === 0) {
+					finish();
+				}
 			};
 
 			xhr.upload.onprogress = function (e) {
@@ -178,41 +180,36 @@ upload.start = {
 
 				// Set progress when progress has changed
 				if (progress > pre_progress) {
-					$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status").html(progress + "%");
+					$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status").html(progress + "%");
 					pre_progress = progress;
 				}
 
-				if (progress >= 100 && next_file_started === false) {
+				if (progress >= 100) {
 					// Scroll to the uploading file
 					let scrollPos = 0;
-					if (file.num + 1 > 4) scrollPos = (file.num + 1 - 4) * 40;
+					if (file_num + 1 > 4) scrollPos = (file_num + 1 - 4) * 40;
 					$(".basicModal .rows").scrollTop(scrollPos);
 
 					// Set status to processing
-					$(".basicModal .rows .row:nth-child(" + (file.num + 1) + ") .status").html(lychee.locale["UPLOAD_PROCESSING"]);
+					$(".basicModal .rows .row:nth-child(" + (file_num + 1) + ") .status").html(lychee.locale["UPLOAD_PROCESSING"]);
+					processing_count++;
+					currently_uploading = false;
 
 					// Upload next file
-					if (file.next != null) {
-						process(files, file.next);
-						next_file_started = true;
+					if ((processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) &&
+						next_upload < files.length) {
+						process(next_upload++);
 					}
 				}
 			};
 
 			xhr.setRequestHeader("X-XSRF-TOKEN", csrf.getCookie("XSRF-TOKEN"));
 			xhr.send(formData);
+			currently_uploading = true;
 		};
 
 		if (files.length <= 0) return false;
 		if (albumID === false || visible.albums() === true) albumID = 0;
-
-		for (let i = 0; i < files.length; i++) {
-			files[i].num = i;
-			files[i].ready = false;
-
-			if (i < files.length - 1) files[i].next = files[i + 1];
-			else files[i].next = null;
-		}
 
 		window.onbeforeunload = function () {
 			return lychee.locale["UPLOAD_IN_PROGRESS"];
@@ -220,7 +217,7 @@ upload.start = {
 
 		upload.show(lychee.locale["UPLOAD_UPLOADING"], files, function () {
 			// Upload first file
-			process(files, files[0]);
+			process(next_upload++);
 		});
 	},
 

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -165,7 +165,7 @@ upload.start = {
 					(processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) &&
 					next_upload < files.length
 				) {
-					process(next_upload++);
+					process(next_upload);
 				}
 
 				// Finish upload when all files are finished
@@ -199,14 +199,16 @@ upload.start = {
 
 					// Upload next file
 					if ((processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) && next_upload < files.length) {
-						process(next_upload++);
+						process(next_upload);
 					}
 				}
 			};
 
+			currently_uploading = true;
+			next_upload++;
+
 			xhr.setRequestHeader("X-XSRF-TOKEN", csrf.getCookie("XSRF-TOKEN"));
 			xhr.send(formData);
-			currently_uploading = true;
 		};
 
 		if (files.length <= 0) return false;
@@ -218,7 +220,7 @@ upload.start = {
 
 		upload.show(lychee.locale["UPLOAD_UPLOADING"], files, function () {
 			// Upload first file
-			process(next_upload++);
+			process(next_upload);
 		});
 	},
 

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -160,9 +160,11 @@ upload.start = {
 				processing_count--;
 
 				// Upload next file
-				if (!currently_uploading &&
+				if (
+					!currently_uploading &&
 					(processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) &&
-					next_upload < files.length) {
+					next_upload < files.length
+				) {
 					process(next_upload++);
 				}
 
@@ -196,8 +198,7 @@ upload.start = {
 					currently_uploading = false;
 
 					// Upload next file
-					if ((processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) &&
-						next_upload < files.length) {
+					if ((processing_count < lychee.upload_processing_limit || lychee.upload_processing_limit === 0) && next_upload < files.length) {
 						process(next_upload++);
 					}
 				}


### PR DESCRIPTION
Implements a limit on the number of photos being simultaneously processed during upload.  I expected that adding this would complicate the `process` function but in fact it simplified it (since it was needlessly complicated to begin with).

This implements what was discussed in  https://github.com/LycheeOrg/Lychee/issues/903 and https://github.com/LycheeOrg/Lychee/issues/913. The default limit is `4`. Setting it to `0` disables the limit.

There will be a trivial corresponding server-side PR that adds a config variable.