### PR TITLE
Fix the timeout handling

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -23,11 +23,18 @@ api.get_url = function (fn) {
 api.isTimeout = function (errorThrown, jqXHR) {
 	if (
 		errorThrown &&
-		errorThrown === "Bad Request" &&
-		jqXHR &&
-		jqXHR.responseJSON &&
-		jqXHR.responseJSON.error &&
-		jqXHR.responseJSON.error === "Session timed out"
+		((errorThrown === "Bad Request" &&
+			jqXHR &&
+			jqXHR.responseJSON &&
+			jqXHR.responseJSON.error &&
+			jqXHR.responseJSON.error === "Session timed out") ||
+			(errorThrown === "unknown status" &&
+				jqXHR &&
+				jqXHR.status &&
+				jqXHR.status === 419 &&
+				jqXHR.responseJSON &&
+				jqXHR.responseJSON.message &&
+				jqXHR.responseJSON.message === "CSRF token mismatch."))
 	) {
 		return true;
 	}


### PR DESCRIPTION
Something changed somewhere (Laravel? Lychee's recent refactoring?) and session timeouts now seem to generate a different response than before. Support this new response in addition to the old one (no idea if the old ones are still generated).