### PR TITLE
add responsive web design for small screens

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -364,6 +364,31 @@ contextMenu.photoMore = function (photoID, e) {
 		{ title: build.iconic("fullscreen-enter") + lychee.locale["FULL_PHOTO"], visible: !!showFull, fn: () => window.open(photo.getDirectLink()) },
 		{ title: build.iconic("cloud-download") + lychee.locale["DOWNLOAD"], visible: !!showDownload, fn: () => photo.getArchive([photoID]) },
 	];
+	// prepend further buttons if menu bar is reduced on small screens
+	let button_visibility = $("#button_visibility");
+	if (button_visibility && button_visibility.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("eye") + lychee.locale["VISIBILITY_PHOTO"],
+			visible: lychee.enable_button_visibility,
+			fn: (e) => photo.setPublic(photo.getID(), e),
+		});
+	}
+	let button_trash = $("#button_trash");
+	if (button_trash && button_trash.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("trash") + lychee.locale["DELETE"],
+			visible: lychee.enable_button_trash,
+			fn: () => photo.delete([photo.getID()]),
+		});
+	}
+	let button_move = $("#button_move");
+	if (button_move && button_move.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("folder") + lychee.locale["MOVE_ALBUM"],
+			visible: lychee.enable_button_move,
+			fn: (e) => contextMenu.move([photo.getID()], e, photo.setAlbum),
+		});
+	}
 
 	basicContext.show(items, e.originalEvent);
 };

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -19,6 +19,40 @@ contextMenu.add = function (e) {
 		items.push({ title: build.iconic("tags") + lychee.locale["NEW_TAG_ALBUM"], fn: album.addByTags });
 	}
 
+	// prepend further buttons if menu bar is reduced on small screens
+	let button_visibility_album = $("#button_visibility_album");
+	if (button_visibility_album && button_visibility_album.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("eye") + lychee.locale["VISIBILITY_ALBUM"],
+			visible: lychee.enable_button_visibility,
+			fn: (event) => album.setPublic(album.getID(), event),
+		});
+	}
+	let button_trash_album = $("#button_trash_album");
+	if (button_trash_album && button_trash_album.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("trash") + lychee.locale["DELETE_ALBUM"],
+			visible: lychee.enable_button_trash,
+			fn: () => album.delete([album.getID()]),
+		});
+	}
+	let button_move_album = $("#button_move_album");
+	if (button_move_album && button_move_album.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("folder") + lychee.locale["MOVE_ALBUM"],
+			visible: lychee.enable_button_move,
+			fn: (event) => contextMenu.move([album.getID()], event, album.setAlbum, "ROOT", album.getParent() != ""),
+		});
+	}
+	let button_nsfw_album = $("#button_nsfw_album");
+	if (button_nsfw_album && button_nsfw_album.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("warning") + lychee.locale["ALBUM_MARK_NSFW"],
+			visible: true,
+			fn: () => album.setNSFW(album.getID()),
+		});
+	}
+
 	if (lychee.api_V2 && !lychee.admin) {
 		items.splice(3, 2);
 	}
@@ -384,7 +418,7 @@ contextMenu.photoMore = function (photoID, e) {
 	let button_move = $("#button_move");
 	if (button_move && button_move.css("display") === "none") {
 		items.unshift({
-			title: build.iconic("folder") + lychee.locale["MOVE_ALBUM"],
+			title: build.iconic("folder") + lychee.locale["MOVE"],
 			visible: lychee.enable_button_move,
 			fn: (event) => contextMenu.move([photo.getID()], event, photo.setAlbum),
 		});

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -370,7 +370,7 @@ contextMenu.photoMore = function (photoID, e) {
 		items.unshift({
 			title: build.iconic("eye") + lychee.locale["VISIBILITY_PHOTO"],
 			visible: lychee.enable_button_visibility,
-			fn: (e) => photo.setPublic(photo.getID(), e),
+			fn: (event) => photo.setPublic(photo.getID(), event),
 		});
 	}
 	let button_trash = $("#button_trash");
@@ -386,7 +386,23 @@ contextMenu.photoMore = function (photoID, e) {
 		items.unshift({
 			title: build.iconic("folder") + lychee.locale["MOVE_ALBUM"],
 			visible: lychee.enable_button_move,
-			fn: (e) => contextMenu.move([photo.getID()], e, photo.setAlbum),
+			fn: (event) => contextMenu.move([photo.getID()], event, photo.setAlbum),
+		});
+	}
+	let button_rotate_cwise = $("#button_rotate_cwise");
+	if (button_rotate_cwise && button_rotate_cwise.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("clockwise") + lychee.locale["PHOTO_EDIT_ROTATECWISE"],
+			visible: lychee.enable_button_move,
+			fn: () => photoeditor.rotate(photo.getID(), 1),
+		});
+	}
+	let button_rotate_ccwise = $("#button_rotate_ccwise");
+	if (button_rotate_ccwise && button_rotate_ccwise.css("display") === "none") {
+		items.unshift({
+			title: build.iconic("counterclockwise") + lychee.locale["PHOTO_EDIT_ROTATECCWISE"],
+			visible: lychee.enable_button_move,
+			fn: () => photoeditor.rotate(photo.getID(), -1),
 		});
 	}
 

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -41,7 +41,7 @@ contextMenu.add = function (e) {
 		items.unshift({
 			title: build.iconic("folder") + lychee.locale["MOVE_ALBUM"],
 			visible: lychee.enable_button_move,
-			fn: (event) => contextMenu.move([album.getID()], event, album.setAlbum, "ROOT", album.getParent() != ""),
+			fn: (event) => contextMenu.move([album.getID()], event, album.setAlbum, "ROOT", album.getParent() !== ""),
 		});
 	}
 	let button_nsfw_album = $("#button_nsfw_album");

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -576,3 +576,41 @@ contextMenu.close = function () {
 		multiselect.close();
 	}
 };
+
+contextMenu.config = function (e) {
+	let items = [{ title: build.iconic("cog") + lychee.locale["SETTINGS"], fn: settings.open }];
+	if (lychee.admin) {
+		items.push({ title: build.iconic("person") + lychee.locale["USERS"], fn: users.list });
+	}
+	items.push({ title: build.iconic("key") + lychee.locale["U2F"], fn: u2f.list });
+	items.push({ title: build.iconic("cloud") + lychee.locale["SHARING"], fn: sharing.list });
+	if (lychee.admin) {
+		items.push({
+			title: build.iconic("align-left") + lychee.locale["LOGS"],
+			fn: function () {
+				if (lychee.api_V2) {
+					view.logs.init();
+				} else {
+					window.open(lychee.logs());
+				}
+			},
+		});
+		items.push({
+			title: build.iconic("wrench") + lychee.locale["DIAGNOSTICS"],
+			fn: function () {
+				if (lychee.api_V2) {
+					view.diagnostics.init();
+				} else {
+					window.open(lychee.diagnostics());
+				}
+			},
+		});
+		if (lychee.api_V2 && lychee.update_available) {
+			items.push({ title: build.iconic("timer") + lychee.locale["UPDATE_AVAILABLE"], fn: view.update.init });
+		}
+	}
+	items.push({ title: build.iconic("info") + lychee.locale["ABOUT_LYCHEE"], fn: lychee.aboutDialog });
+	items.push({ title: build.iconic("account-logout") + lychee.locale["SIGN_OUT"], fn: lychee.logout });
+
+	basicContext.show(items, e.originalEvent);
+};

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -19,6 +19,10 @@ contextMenu.add = function (e) {
 		items.push({ title: build.iconic("tags") + lychee.locale["NEW_TAG_ALBUM"], fn: album.addByTags });
 	}
 
+	if (lychee.api_V2 && !lychee.admin) {
+		items.splice(3, 2);
+	}
+
 	// prepend further buttons if menu bar is reduced on small screens
 	let button_visibility_album = $("#button_visibility_album");
 	if (button_visibility_album && button_visibility_album.css("display") === "none") {
@@ -51,10 +55,6 @@ contextMenu.add = function (e) {
 			visible: true,
 			fn: () => album.setNSFW(album.getID()),
 		});
-	}
-
-	if (lychee.api_V2 && !lychee.admin) {
-		items.splice(3, 2);
 	}
 
 	basicContext.show(items, e.originalEvent);

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -526,7 +526,9 @@ header.setMode = function (mode) {
 
 			tabindex.makeFocusable(header.dom(".header__toolbar--map"));
 			tabindex.makeUnfocusable(
-				header.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo")
+				header.dom(
+					".header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--config"
+				)
 			);
 			return true;
 		case "config":

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -44,7 +44,22 @@ header.bind = function () {
 	});
 
 	header.dom("#button_signin").on(eventName, lychee.loginDialog);
-	header.dom("#button_settings").on(eventName, leftMenu.open);
+	header.dom("#button_settings").on(eventName, function (e) {
+		if ($(".leftMenu").css("display") === "none") {
+			// left menu disabled on small screens
+			contextMenu.config(e);
+		} else {
+			// standard left menu
+			leftMenu.open();
+		}
+	});
+	header.dom("#button_close_config").on(eventName, function () {
+		tabindex.makeFocusable(header.dom());
+		tabindex.makeFocusable(lychee.content);
+		tabindex.makeUnfocusable(leftMenu._dom);
+		multiselect.bind();
+		lychee.load();
+	});
 	header.dom("#button_info_album").on(eventName, sidebar.toggle);
 	header.dom("#button_info").on(eventName, sidebar.toggle);
 	header.dom(".button--map-albums").on(eventName, function () {
@@ -185,11 +200,15 @@ header.setMode = function (mode) {
 		case "public":
 			header.dom().removeClass("header--view");
 			header
-				.dom(".header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map")
+				.dom(".header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config")
 				.removeClass("header__toolbar--visible");
 			header.dom(".header__toolbar--public").addClass("header__toolbar--visible");
 			tabindex.makeFocusable(header.dom(".header__toolbar--public"));
-			tabindex.makeUnfocusable(header.dom(".header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map"));
+			tabindex.makeUnfocusable(
+				header.dom(
+					".header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config"
+				)
+			);
 
 			if (lychee.public_search) {
 				let e = $(".header__search, .header__clear", ".header__toolbar--public");
@@ -221,12 +240,16 @@ header.setMode = function (mode) {
 		case "albums":
 			header.dom().removeClass("header--view");
 			header
-				.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map")
+				.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config")
 				.removeClass("header__toolbar--visible");
 			header.dom(".header__toolbar--albums").addClass("header__toolbar--visible");
 
 			tabindex.makeFocusable(header.dom(".header__toolbar--albums"));
-			tabindex.makeUnfocusable(header.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map"));
+			tabindex.makeUnfocusable(
+				header.dom(
+					".header__toolbar--public, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config"
+				)
+			);
 
 			// If map is disabled, we should hide the icon
 			if (lychee.map_display) {
@@ -255,13 +278,15 @@ header.setMode = function (mode) {
 
 			header.dom().removeClass("header--view");
 			header
-				.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map")
+				.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config")
 				.removeClass("header__toolbar--visible");
 			header.dom(".header__toolbar--album").addClass("header__toolbar--visible");
 
 			tabindex.makeFocusable(header.dom(".header__toolbar--album"));
 			tabindex.makeUnfocusable(
-				header.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map")
+				header.dom(
+					".header__toolbar--public, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--map, .header__toolbar--config"
+				)
 			);
 
 			// Hide download button when album empty or we are not allowed to
@@ -401,13 +426,15 @@ header.setMode = function (mode) {
 		case "photo":
 			header.dom().addClass("header--view");
 			header
-				.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map")
+				.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map, .header__toolbar--config")
 				.removeClass("header__toolbar--visible");
 			header.dom(".header__toolbar--photo").addClass("header__toolbar--visible");
 
 			tabindex.makeFocusable(header.dom(".header__toolbar--photo"));
 			tabindex.makeUnfocusable(
-				header.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map")
+				header.dom(
+					".header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--map, .header__toolbar--config"
+				)
 			);
 			// If map is disabled, we should hide the icon
 			if (lychee.publicMode === true ? lychee.map_display_public : lychee.map_display) {
@@ -493,7 +520,7 @@ header.setMode = function (mode) {
 		case "map":
 			header.dom().removeClass("header--view");
 			header
-				.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo")
+				.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo, .header__toolbar--config")
 				.removeClass("header__toolbar--visible");
 			header.dom(".header__toolbar--map").addClass("header__toolbar--visible");
 
@@ -501,6 +528,13 @@ header.setMode = function (mode) {
 			tabindex.makeUnfocusable(
 				header.dom(".header__toolbar--public, .header__toolbar--album, .header__toolbar--albums, .header__toolbar--photo")
 			);
+			return true;
+		case "config":
+			header.dom().addClass("header--view");
+			header
+				.dom(".header__toolbar--public, .header__toolbar--albums, .header__toolbar--album, .header__toolbar--photo, .header__toolbar--map")
+				.removeClass("header__toolbar--visible");
+			header.dom(".header__toolbar--config").addClass("header__toolbar--visible");
 			return true;
 	}
 

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -387,7 +387,7 @@ header.setMode = function (mode) {
 				let e = $("#button_trash_album", ".header__toolbar--album");
 				e.remove();
 			}
-			if (!lychee.enable_button_fullscreen) {
+			if (!lychee.enable_button_fullscreen || !lychee.fullscreenAvailable()) {
 				let e = $("#button_fs_album_enter", ".header__toolbar--album");
 				e.remove();
 			}
@@ -474,7 +474,7 @@ header.setMode = function (mode) {
 				let e = $("#button_trash", ".header__toolbar--photo");
 				e.remove();
 			}
-			if (!lychee.enable_button_fullscreen) {
+			if (!lychee.enable_button_fullscreen || !lychee.fullscreenAvailable()) {
 				let e = $("#button_fs_enter", ".header__toolbar--photo");
 				e.remove();
 			}

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -129,7 +129,6 @@ header.bind = function () {
 		}
 	});
 	header.dom(".header__clear").on(eventName, function () {
-		header.dom(".header__search").focus();
 		search.reset();
 	});
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -339,9 +339,10 @@ $(document).ready(function () {
 					return false;
 				}
 			}
-		})
-		// Fullscreen
-		.on("fullscreenchange mozfullscreenchange webkitfullscreenchange msfullscreenchange", lychee.fullscreenUpdate);
+		});
+	// Fullscreen
+	if (lychee.fullscreenAvailable())
+		$(document).on("fullscreenchange mozfullscreenchange webkitfullscreenchange msfullscreenchange", lychee.fullscreenUpdate);
 
 	$("#sensitive_warning").on("click", view.album.nsfw_warning.next);
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -211,7 +211,7 @@ $(document).ready(function () {
 
 	Mousetrap.bindGlobal(["esc", "command+up"], function () {
 		if (basicModal.visible() === true) basicModal.cancel();
-		else if (visible.leftMenu()) leftMenu.close();
+		else if (visible.config() || visible.leftMenu()) leftMenu.close();
 		else if (visible.contextMenu()) contextMenu.close();
 		else if (visible.photo()) lychee.goto(album.getID());
 		else if (visible.album() && !album.json.parent_id) lychee.goto();
@@ -295,6 +295,7 @@ $(document).ready(function () {
 				visible.contextMenu() ||
 				basicModal.visible() ||
 				visible.leftMenu() ||
+				visible.config() ||
 				!(visible.album() || visible.albums())
 			) {
 				return false;
@@ -331,6 +332,7 @@ $(document).ready(function () {
 						!visible.contextMenu() &&
 						!basicModal.visible() &&
 						!visible.leftMenu() &&
+						!visible.config() &&
 						(visible.album() || visible.albums())
 					) {
 						upload.start.local(filesToUpload);

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -852,6 +852,10 @@ lychee.fullscreenStatus = function () {
 	return elem ? true : false;
 };
 
+lychee.fullscreenAvailable = function () {
+	return document.requestFullscreen || document.mozRequestFullscreen || document.webkitRequestFullscreen || document.msRequestFullscreen;
+};
+
 lychee.fullscreenUpdate = function () {
 	if (lychee.fullscreenStatus()) {
 		$("#button_fs_album_enter,#button_fs_enter").hide();

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -853,7 +853,7 @@ lychee.fullscreenStatus = function () {
 };
 
 lychee.fullscreenAvailable = function () {
-	return document.requestFullscreen || document.mozRequestFullscreen || document.webkitRequestFullscreen || document.msRequestFullscreen;
+	return document.fullscreenEnabled || document.mozFullscreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled;
 };
 
 lychee.fullscreenUpdate = function () {

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -580,7 +580,7 @@ view.album = {
 	},
 
 	sidebar: function () {
-		if ((visible.album() || !album.json.init) && !visible.photo()) {
+		if ((visible.album() || (album.json !== null && album.json.init !== null)) && !visible.photo()) {
 			let structure = sidebar.createStructure.album(album);
 			let html = sidebar.render(structure);
 
@@ -884,6 +884,7 @@ view.settings = {
 
 		view.photo.hide();
 		view.settings.title();
+		header.setMode("config");
 		view.settings.content.init();
 	},
 
@@ -1514,6 +1515,7 @@ view.users = {
 
 		view.photo.hide();
 		view.users.title();
+		header.setMode("config");
 		view.users.content.init();
 	},
 
@@ -1602,6 +1604,7 @@ view.sharing = {
 
 		view.photo.hide();
 		view.sharing.title();
+		header.setMode("config");
 		view.sharing.content.init();
 	},
 
@@ -1745,6 +1748,7 @@ view.logs = {
 
 		view.photo.hide();
 		view.logs.title();
+		header.setMode("config");
 		view.logs.content.init();
 	},
 
@@ -1783,6 +1787,7 @@ view.diagnostics = {
 
 		view.photo.hide();
 		view.diagnostics.title("Diagnostics");
+		header.setMode("config");
 		view.diagnostics.content.init();
 	},
 
@@ -1908,6 +1913,7 @@ view.update = {
 
 		view.photo.hide();
 		view.update.title();
+		header.setMode("config");
 		view.update.content.init();
 	},
 
@@ -1954,6 +1960,7 @@ view.u2f = {
 
 		view.photo.hide();
 		view.u2f.title();
+		header.setMode("config");
 		view.u2f.content.init();
 	},
 

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -580,7 +580,7 @@ view.album = {
 	},
 
 	sidebar: function () {
-		if ((visible.album() || (album.json !== null && album.json.init !== null)) && !visible.photo()) {
+		if ((visible.album() || (album.json && album.json.init)) && !visible.photo()) {
 			let structure = sidebar.createStructure.album(album);
 			let html = sidebar.render(structure);
 

--- a/scripts/main/visible.js
+++ b/scripts/main/visible.js
@@ -25,6 +25,11 @@ visible.mapview = function () {
 	return false;
 };
 
+visible.config = function () {
+	if (header.dom(".header__toolbar--config").hasClass("header__toolbar--visible")) return true;
+	return false;
+};
+
 visible.search = function () {
 	if (search.hash != null) return true;
 	return false;

--- a/styles/main/_basicModal.custom.scss
+++ b/styles/main/_basicModal.custom.scss
@@ -16,3 +16,30 @@
 		border-top: 1px solid rgba(0, 0, 0, 0.2);
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.basicModal {
+		max-width: 90%;
+
+		.basicModal__content,
+		.basicModal__content .choice,
+		.basicModal__content .switch {
+			h1,
+			p {
+				padding-left: 20px;
+				padding-right: 20px;
+			}
+
+			p {
+				font-size: 12px;
+				line-height: 14px;
+			}
+
+			h1 {
+				font-size: 14px;
+				line-height: 16px;
+			}
+		}
+	}
+}

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -296,6 +296,151 @@
 	}
 }
 
+// responsive web design for smaller screens
+@media only screen and (min-width: 320px) and (max-width: 567px) {
+	.content {
+		padding: 50px 0 33px 0;
+		width: 100%;
+		max-width: 100%;
+
+		.album,
+		.photo {
+			// 3 thumbnails per row
+			--size: calc((100vw - 3px) / 3);
+			width: calc(var(--size) - 3px);
+			height: calc(var(--size) - 3px);
+			margin: 3px 0 0 3px;
+			.thumbimg {
+				width: calc(var(--size) - 5px);
+				height: calc(var(--size) - 5px);
+			}
+			.overlay {
+				width: calc(var(--size) - 5px);
+				h1 {
+					min-height: 14px;
+					width: calc(var(--size) - 19px);
+					margin: 8px 0 2px 6px;
+					font-size: 12px;
+				}
+				a {
+					// suppress subtitles on small screens
+					display: none;
+				}
+			}
+			.badge {
+				padding: 4px 3px 3px;
+				width: 12px;
+				.iconic {
+					width: 12px;
+					height: 12px;
+				}
+				&--folder {
+					.iconic {
+						width: 8px;
+						height: 8px;
+					}
+				}
+			}
+		}
+	}
+}
+
+@media only screen and (min-width: 568px) and (max-width: 639px) {
+	.content {
+		padding: 50px 0 33px 0;
+		width: 100%;
+		max-width: 100%;
+
+		.album,
+		.photo {
+			// 4 thumbnails per row
+			--size: calc((100vw - 3px) / 4);
+			width: calc(var(--size) - 3px);
+			height: calc(var(--size) - 3px);
+			margin: 3px 0 0 3px;
+			.thumbimg {
+				width: calc(var(--size) - 5px);
+				height: calc(var(--size) - 5px);
+			}
+			.overlay {
+				width: calc(var(--size) - 5px);
+				h1 {
+					min-height: 14px;
+					width: calc(var(--size) - 19px);
+					margin: 8px 0 2px 6px;
+					font-size: 12px;
+				}
+				a {
+					// suppress subtitles on small screens
+					display: none;
+				}
+			}
+			.badge {
+				padding: 4px 3px 3px;
+				width: 14px;
+				.iconic {
+					width: 14px;
+					height: 14px;
+				}
+				&--folder {
+					.iconic {
+						width: 9px;
+						height: 9px;
+					}
+				}
+			}
+		}
+	}
+}
+
+@media only screen and (min-width: 640px) and (max-width: 768px) {
+	.content {
+		padding: 50px 0 33px 0;
+		width: 100%;
+		max-width: 100%;
+
+		.album,
+		.photo {
+			// 5 thumbnails per row
+			--size: calc((100vw - 5px) / 5);
+			width: calc(var(--size) - 5px);
+			height: calc(var(--size) - 5px);
+			margin: 5px 0 0 5px;
+			.thumbimg {
+				width: calc(var(--size) - 7px);
+				height: calc(var(--size) - 7px);
+			}
+			.overlay {
+				width: calc(var(--size) - 7px);
+				h1 {
+					min-height: 14px;
+					width: calc(var(--size) - 21px);
+					margin: 10px 0 3px 8px;
+					font-size: 12px;
+				}
+				a {
+					// suppress subtitles on small screens
+					display: none;
+				}
+			}
+			.badge {
+				padding: 6px 4px 4px;
+				width: 16px;
+				.iconic {
+					width: 16px;
+					height: 16px;
+				}
+				&--folder {
+					.iconic {
+						width: 10px;
+						height: 10px;
+					}
+				}
+			}
+		}
+	}
+}
+
 // No content -------------------------------------------------------------- //
 .no_content {
 	position: absolute;

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -342,6 +342,16 @@
 				}
 			}
 		}
+		.divider {
+			margin: 20px 0 0;
+			&:first-child {
+				margin-top: 0;
+			}
+			h1 {
+				margin: 0 0 6px 8px;
+				font-size: 12px;
+			}
+		}
 	}
 }
 
@@ -390,6 +400,15 @@
 				}
 			}
 		}
+		.divider {
+			margin: 24px 0 0;
+			&:first-child {
+				margin-top: 0;
+			}
+			h1 {
+				margin: 0 0 6px 10px;
+			}
+		}
 	}
 }
 
@@ -436,6 +455,15 @@
 						height: 10px;
 					}
 				}
+			}
+		}
+		.divider {
+			margin: 28px 0 0;
+			&:first-child {
+				margin-top: 0;
+			}
+			h1 {
+				margin: 0 0 6px 10px;
 			}
 		}
 	}

--- a/styles/main/_header.scss
+++ b/styles/main/_header.scss
@@ -21,7 +21,7 @@
 	}
 
 	&--view {
-		background: none;
+		background: rgba(0, 0, 0, 0.6);
 		border-bottom: none;
 
 		&.header--error {

--- a/styles/main/_header.scss
+++ b/styles/main/_header.scss
@@ -21,7 +21,6 @@
 	}
 
 	&--view {
-		background: rgba(0, 0, 0, 0.6);
 		border-bottom: none;
 
 		&.header--error {
@@ -41,6 +40,16 @@
 
 		&--visible {
 			display: flex;
+		}
+
+		&--config {
+			.button .iconic {
+				transform: rotate(45deg);
+			}
+
+			.header__title {
+				padding-right: 80px;
+			}
 		}
 	}
 
@@ -135,8 +144,9 @@
 	}
 
 	#button_settings,
-	#button_signin {
-		padding: 16px 48px 16px 8px;
+	#button_signin,
+	#button_close_config {
+		padding: 16px 48px 16px 18px;
 	}
 
 	// Divider -------------------------------------------------------------- //
@@ -219,6 +229,7 @@
 	}
 }
 
+// responsive web design for smaller screens
 @media only screen and (max-width: 640px) {
 	// reduce entries in menu bar on small screens
 	// corresponding entries are added to the 'more' menu

--- a/styles/main/_header.scss
+++ b/styles/main/_header.scss
@@ -254,5 +254,9 @@
 		#button_rotate_cwise {
 			display: none !important;
 		}
+
+		.header__divider {
+			width: 0;
+		}
 	}
 }

--- a/styles/main/_header.scss
+++ b/styles/main/_header.scss
@@ -218,3 +218,25 @@
 		margin-left: 250px;
 	}
 }
+
+@media only screen and (max-width: 640px) {
+	// reduce entries in menu bar on small screens
+	// corresponding entries are added to the 'more' menu
+	#button_move,
+	#button_move_album,
+	#button_trash,
+	#button_trash_album,
+	#button_visibility,
+	#button_visibility_album,
+	#button_nsfw_album {
+		display: none !important;
+	}
+
+	@media (max-width: 567px) {
+		// remove further buttons on tiny screens
+		#button_rotate_ccwise,
+		#button_rotate_cwise {
+			display: none !important;
+		}
+	}
+}

--- a/styles/main/_header.scss
+++ b/styles/main/_header.scss
@@ -184,14 +184,19 @@
 		&::-ms-clear {
 			display: none;
 		}
+
+		&__field {
+			position: relative;
+		}
 	}
 
 	&__clear {
 		position: absolute;
-		right: 90px;
+		top: -2px;
+		right: 8px;
 		padding: 0;
 		color: white(0.5);
-		font-size: 30px;
+		font-size: 24px;
 		opacity: 0;
 		transition: color 0.2s ease-out;
 		cursor: default;

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -219,24 +219,6 @@
 	}
 }
 
-@media only screen and (max-width: 640px) {
-	// reduce entries in menu bar on small screens
-	// corresponding entries are added to the 'more' menu
-	#button_move,
-	#button_trash,
-	#button_visibility {
-		display: none !important;
-	}
-
-	@media (max-width: 567px) {
-		// remove further buttons on tiny screens
-		#button_rotate_ccwise,
-		#button_rotate_cwise {
-			display: none !important;
-		}
-	}
-}
-
 @media only screen and (min-width: 568px) and (max-width: 768px),
 	only screen and (min-width: 568px) and (max-width: 640px) and (orientation: landscape) {
 	// sidebar on side, medium size

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -217,13 +217,23 @@
 			}
 		}
 	}
+}
 
+@media only screen and (max-width: 640px) {
 	// reduce entries in menu bar on small screens
 	// corresponding entries are added to the 'more' menu
 	#button_move,
 	#button_trash,
 	#button_visibility {
 		display: none !important;
+	}
+
+	@media (max-width: 567px) {
+		// remove further buttons on tiny screens
+		#button_rotate_ccwise,
+		#button_rotate_cwise {
+			display: none !important;
+		}
 	}
 }
 

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -217,6 +217,14 @@
 			}
 		}
 	}
+
+	// reduce entries in menu bar on small screens
+	// corresponding entries are added to the 'more' menu
+	#button_move,
+	#button_trash,
+	#button_visibility {
+		display: none !important;
+	}
 }
 
 @media only screen and (min-width: 568px) and (max-width: 768px),

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -19,36 +19,7 @@
 	}
 
 	// ImageView -------------------------------------------------------------- //
-	#image {
-		position: absolute;
-		top: 60px;
-		right: 30px;
-		bottom: 30px;
-		left: 30px;
-		margin: auto;
-		max-width: calc(100% - 60px);
-		max-height: calc(100% - 90px);
-		width: auto;
-		height: auto;
-		transition: top 0.3s, right 0.3s, bottom 0.3s, left 0.3s, max-width 0.3s, max-height 0.3s;
-
-		animation-name: zoomIn;
-		animation-duration: 0.3s;
-		animation-timing-function: $timingBounce;
-		background-size: contain;
-		background-position: center;
-		background-repeat: no-repeat;
-
-		@media (max-width: 640px) {
-			top: 60px;
-			right: 20px;
-			bottom: 20px;
-			left: 20px;
-			max-width: calc(100% - 40px);
-			max-height: calc(100% - 80px);
-		}
-	}
-
+	#image,
 	#livephoto {
 		position: absolute;
 		top: 60px;
@@ -68,26 +39,9 @@
 		background-size: contain;
 		background-position: center;
 		background-repeat: no-repeat;
-
-		@media (max-width: 640px) {
-			top: 60px;
-			right: 20px;
-			bottom: 20px;
-			left: 20px;
-			max-width: calc(100% - 40px);
-			max-height: calc(100% - 80px);
-		}
 	}
 
-	&.full #image {
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		max-width: 100%;
-		max-height: 100%;
-	}
-
+	&.full #image,
 	&.full #livephoto {
 		top: 0;
 		right: 0;
@@ -97,24 +51,10 @@
 		max-height: 100%;
 	}
 
-	&.image--sidebar #image {
-		right: 380px;
-		max-width: calc(100% - 410px);
-
-		@media (max-width: 640px) {
-			right: 370px;
-			max-width: calc(100% - 390px);
-		}
-	}
-
+	&.image--sidebar #image,
 	&.image--sidebar #livephoto {
 		right: 380px;
 		max-width: calc(100% - 410px);
-
-		@media (max-width: 640px) {
-			right: 370px;
-			max-width: calc(100% - 390px);
-		}
 	}
 
 	#image_overlay {
@@ -165,10 +105,6 @@
 
 		&--next {
 			right: 0;
-		}
-
-		@media (max-width: 640px) {
-			display: none;
 		}
 
 		a {
@@ -233,59 +169,105 @@
 }
 
 // responsive web design for smaller screens
-@media only screen and (min-width: 320px) and (max-width: 567px) {
-	#imageview #image_overlay {
-		h1 {
-			font-size: 14px;
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	// sidebar as overlay, small size
+	#imageview {
+		#image,
+		#livephoto {
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			max-width: 100%;
+			max-height: 100%;
 		}
 
-		p {
-			margin-top: 2px;
-			font-size: 11px;
-			line-height: 13px;
+		&.image--sidebar {
+			#image,
+			#livephoto {
+				right: 0;
+				max-width: 100%;
+			}
+
+			.arrow_wrapper {
+				&--next {
+					right: 0;
+				}
+
+				a#next {
+					right: -1px;
+				}
+			}
 		}
 
-		a .iconic {
-			width: 9px;
-			height: 9px;
+		#image_overlay {
+			h1 {
+				font-size: 14px;
+			}
+
+			p {
+				margin-top: 2px;
+				font-size: 11px;
+				line-height: 13px;
+			}
+
+			a .iconic {
+				width: 9px;
+				height: 9px;
+			}
 		}
 	}
 }
 
-@media only screen and (min-width: 568px) and (max-width: 639px) {
-	#imageview #image_overlay {
-		h1 {
-			font-size: 16px;
+@media only screen and (min-width: 568px) and (max-width: 768px),
+	only screen and (min-width: 568px) and (max-width: 640px) and (orientation: landscape) {
+	// sidebar on side, medium size
+	#imageview {
+		#image,
+		#livephoto {
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			max-width: 100%;
+			max-height: 100%;
 		}
 
-		p {
-			margin-top: 3px;
-			font-size: 12px;
-			line-height: 14px;
+		&.image--sidebar {
+			#image,
+			#livephoto {
+				top: 50px;
+				right: 280px;
+				max-width: calc(100% - 280px);
+				max-height: calc(100% - 50px);
+			}
+
+			.arrow_wrapper {
+				&--next {
+					right: 280px;
+				}
+
+				a#next {
+					right: 279px;
+				}
+			}
 		}
 
-		a .iconic {
-			width: 10px;
-			height: 10px;
-		}
-	}
-}
+		#image_overlay {
+			h1 {
+				font-size: 18px;
+			}
 
-@media only screen and (min-width: 640px) and (max-width: 768px) {
-	#imageview #image_overlay {
-		h1 {
-			font-size: 18px;
-		}
+			p {
+				margin-top: 4px;
+				font-size: 14px;
+				line-height: 16px;
+			}
 
-		p {
-			margin-top: 4px;
-			font-size: 14px;
-			line-height: 16px;
-		}
-
-		a .iconic {
-			width: 12px;
-			height: 12px;
+			a .iconic {
+				width: 12px;
+				height: 12px;
+			}
 		}
 	}
 }

--- a/styles/main/_imageview.scss
+++ b/styles/main/_imageview.scss
@@ -231,3 +231,61 @@
 		z-index: 1;
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (min-width: 320px) and (max-width: 567px) {
+	#imageview #image_overlay {
+		h1 {
+			font-size: 14px;
+		}
+
+		p {
+			margin-top: 2px;
+			font-size: 11px;
+			line-height: 13px;
+		}
+
+		a .iconic {
+			width: 9px;
+			height: 9px;
+		}
+	}
+}
+
+@media only screen and (min-width: 568px) and (max-width: 639px) {
+	#imageview #image_overlay {
+		h1 {
+			font-size: 16px;
+		}
+
+		p {
+			margin-top: 3px;
+			font-size: 12px;
+			line-height: 14px;
+		}
+
+		a .iconic {
+			width: 10px;
+			height: 10px;
+		}
+	}
+}
+
+@media only screen and (min-width: 640px) and (max-width: 768px) {
+	#imageview #image_overlay {
+		h1 {
+			font-size: 18px;
+		}
+
+		p {
+			margin-top: 4px;
+			font-size: 14px;
+			line-height: 16px;
+		}
+
+		a .iconic {
+			width: 12px;
+			height: 12px;
+		}
+	}
+}

--- a/styles/main/_justified_layout.scss
+++ b/styles/main/_justified_layout.scss
@@ -45,3 +45,31 @@
 	width: auto;
 	margin-right: 15px;
 }
+
+// responsive web design for smaller screens
+@media only screen and (min-width: 320px) and (max-width: 567px) {
+	.content > .justified-layout {
+		margin: 8px 8px 0 8px;
+		.photo {
+			--lychee-default-height: 160px;
+		}
+	}
+}
+
+@media only screen and (min-width: 568px) and (max-width: 639px) {
+	.content > .justified-layout {
+		margin: 9px 9px 0 9px;
+		.photo {
+			--lychee-default-height: 200px;
+		}
+	}
+}
+
+@media only screen and (min-width: 640px) and (max-width: 768px) {
+	.content > .justified-layout {
+		margin: 10px 10px 0 10px;
+		.photo {
+			--lychee-default-height: 240px;
+		}
+	}
+}

--- a/styles/main/_leftMenu.scss
+++ b/styles/main/_leftMenu.scss
@@ -8,7 +8,7 @@
 	left: 0;
 	background-color: #111; /* Black*/
 	overflow-x: hidden; /* Disable horizontal scroll */
-	padding-top: 60px; /* Place content 60px from the top */
+	padding-top: 49px; /* Place content 49px from the top (same as menu bar height) */
 	transition: 0.5s; /* 0.5 second transition effect to slide in the sidenav */
 }
 
@@ -73,12 +73,10 @@
 	width: 250px;
 }
 
-/* On smaller screens, where height is less than 450px, change the style of the sidenav (less padding and a smaller font size) */
-@media screen and (max-height: 450px) {
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	// disable left menu on small devices and use context menu instead
 	.leftMenu {
-		padding-top: 15px;
-	}
-	.leftMenu a {
-		font-size: 18px;
+		display: none !important;
 	}
 }

--- a/styles/main/_logs_diagnostics.scss
+++ b/styles/main/_logs_diagnostics.scss
@@ -1,5 +1,5 @@
 .logs_diagnostics_view {
-	width: 1200px;
+	width: 90%;
 	margin-left: auto;
 	margin-right: auto;
 	color: #ccc;
@@ -12,11 +12,12 @@
 		-moz-user-select: text;
 		-ms-user-select: text;
 		user-select: text;
+		width: fit-content;
+		padding-right: 30px;
 	}
 }
 
 .clear_logs_update {
-	width: 1200px;
 	margin-left: auto;
 	margin-right: auto;
 	margin-bottom: 20px;

--- a/styles/main/_logs_diagnostics.scss
+++ b/styles/main/_logs_diagnostics.scss
@@ -48,3 +48,32 @@
 		width: 400px;
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.logs_diagnostics_view,
+	.clear_logs_update {
+		width: 100%;
+		max-width: 100%;
+		font-size: 11px;
+		line-height: 12px;
+
+		.basicModal__button,
+		.button_left {
+			width: 80%;
+			margin: 0 10%;
+		}
+	}
+
+	.logs_diagnostics_view {
+		padding: 10px 10px 0 0;
+	}
+
+	.clear_logs_update {
+		padding: 10px 10px 0 10px;
+	}
+
+	.clear_logs_update {
+		margin: 0;
+	}
+}

--- a/styles/main/_logs_diagnostics.scss
+++ b/styles/main/_logs_diagnostics.scss
@@ -71,9 +71,6 @@
 
 	.clear_logs_update {
 		padding: 10px 10px 0 10px;
-	}
-
-	.clear_logs_update {
 		margin: 0;
 	}
 }

--- a/styles/main/_settings.scss
+++ b/styles/main/_settings.scss
@@ -1,53 +1,12 @@
 .settings_view {
-	width: 80%;
-	max-width: 600px;
+	width: 90%;
+	max-width: 700px;
 	margin-left: auto;
 	margin-right: auto;
-}
-
-.setLogin,
-.setSorting,
-.setDropBox,
-.setLang,
-.setLayout,
-.setPublicSearch,
-.setOverlay,
-.setOverlayType,
-.setMapDisplay,
-.setMapDisplayPublic,
-.setMapProvider,
-.setMapIncludeSubalbums,
-.setLocationDecoding,
-.setLocationDecodingCachingType,
-.setLocationShow,
-.setLocationShowPublic,
-.setDefaultLicense,
-.setCSS,
-.setNSFWVisible {
-	font-size: 14px;
-	width: 100%;
-	padding: 5%;
-
-	p {
-		margin: 0 0 5%;
-		width: 100%;
-		color: #ccc;
-		line-height: 16px;
-
-		a {
-			color: rgba(255, 255, 255, 0.9);
-			text-decoration: none;
-			border-bottom: 1px dashed #888;
-		}
-	}
-
-	p:last-of-type {
-		margin: 0;
-	}
 
 	input.text {
 		padding: 9px 2px;
-		width: 100%;
+		width: calc(50% - 4px);
 		background-color: transparent;
 		color: #fff;
 		border: none;
@@ -55,82 +14,15 @@
 		border-radius: 0;
 		box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
 		outline: 0;
-	}
 
-	input.text:focus {
-		border-bottom-color: #2293ec;
-	}
-
-	input.text.error {
-		border-bottom-color: #d92c34;
-	}
-
-	input.text:first-child {
-		margin-top: 10px;
-	}
-
-	input.text:last-child {
-		margin-bottom: 10px;
-	}
-
-	textarea {
-		padding: 9px 9px;
-		width: calc(100% - 18px);
-		height: 100px;
-		background-color: transparent;
-		color: #fff;
-		border: 1px solid #666666;
-		border-radius: 0;
-		box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
-		outline: 0;
-		resize: vertical;
-
-		&:focus {
-			border-color: #2293ec;
+		&:focus,
+		&:hover {
+			border-bottom-color: #2293ec;
 		}
-	}
 
-	.choice {
-		padding: 0 30px 15px;
-		width: 100%;
-		color: #fff;
-	}
-
-	.choice:last-child {
-		padding-bottom: 40px;
-	}
-
-	.choice label {
-		float: left;
-		color: #fff;
-		font-size: 14px;
-		font-weight: 700;
-	}
-
-	.choice label input {
-		position: absolute;
-		margin: 0;
-		opacity: 0;
-	}
-
-	.choice label .checkbox {
-		float: left;
-		display: block;
-		width: 16px;
-		height: 16px;
-		background: rgba(0, 0, 0, 0.5);
-		border-radius: 3px;
-		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.7);
-	}
-
-	.choice label .checkbox .iconic {
-		box-sizing: border-box;
-		fill: #2293ec;
-		padding: 2px;
-		opacity: 0;
-		-ms-transform: scale(0);
-		transform: scale(0);
-		transition: opacity 0.2s cubic-bezier(0.51, 0.92, 0.24, 1), transform 0.2s cubic-bezier(0.51, 0.92, 0.24, 1);
+		.error {
+			border-bottom-color: #d92c34;
+		}
 	}
 
 	.basicModal__button {
@@ -138,15 +30,16 @@
 		display: inline-block;
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), inset 1px 0 0 rgba(0, 0, 0, 0.2);
 		border-radius: 5px;
+
+		&:hover {
+			background: #2293ec;
+			color: #ffffff;
+			cursor: pointer;
+		}
 	}
 
-	.basicModal__button:hover {
-		background: #2293ec;
-		color: #ffffff;
-		cursor: pointer;
-	}
-
-	.basicModal__button_MORE {
+	.basicModal__button_MORE,
+	.basicModal__button_SAVE {
 		color: #b22027;
 		border-radius: 5px;
 
@@ -156,137 +49,214 @@
 		}
 	}
 
-	input:hover {
-		border-bottom: #2293ec solid 1px;
-	}
+	> div {
+		font-size: 14px;
+		width: 100%;
+		padding: 12px 0;
 
-	.select {
-		position: relative;
-		margin: 1px 5px;
-		padding: 0;
-		width: 110px;
-		color: #fff;
-		border-radius: 3px;
-		border: 1px solid rgba(0, 0, 0, 0.2);
-		box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02);
-		font-size: 11px;
-		line-height: 16px;
-		overflow: hidden;
-		outline: 0;
-		vertical-align: middle;
-		background: rgba(0, 0, 0, 0.3);
-		display: inline-block;
-		select {
-			margin: 0;
-			padding: 4px 8px;
-			width: 120%;
-			color: #fff;
-			font-size: 11px;
+		p {
+			margin: 0 0 5%;
+			width: 100%;
+			color: #ccc;
 			line-height: 16px;
-			border: 0;
-			outline: 0;
-			box-shadow: none;
-			border-radius: 0;
-			background-color: transparent;
-			background-image: none;
-			-moz-appearance: none;
-			-webkit-appearance: none;
-			appearance: none;
 
-			option {
-				margin: 0;
-				padding: 0;
-				background: #fff;
-				color: #333;
-				transition: none;
+			a {
+				color: rgba(255, 255, 255, 0.9);
+				text-decoration: none;
+				border-bottom: 1px dashed #888;
 			}
 		}
-		select:disabled {
-			color: #000;
-			cursor: not-allowed;
+
+		p:last-of-type {
+			margin: 0;
+		}
+
+		input.text {
+			width: 100%;
+		}
+
+		textarea {
+			padding: 9px 9px;
+			width: calc(100% - 18px);
+			height: 100px;
+			background-color: transparent;
+			color: #fff;
+			border: 1px solid #666666;
+			border-radius: 0;
+			box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+			outline: 0;
+			resize: vertical;
+
+			&:focus {
+				border-color: #2293ec;
+			}
+		}
+
+		.choice {
+			padding: 0 30px 15px;
+			width: 100%;
+			color: #fff;
+		}
+
+		.choice:last-child {
+			padding-bottom: 40px;
+		}
+
+		.choice label {
+			float: left;
+			color: #fff;
+			font-size: 14px;
+			font-weight: 700;
+		}
+
+		.choice label input {
+			position: absolute;
+			margin: 0;
+			opacity: 0;
+		}
+
+		.choice label .checkbox {
+			float: left;
+			display: block;
+			width: 16px;
+			height: 16px;
+			background: rgba(0, 0, 0, 0.5);
+			border-radius: 3px;
+			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.7);
+		}
+
+		.choice label .checkbox .iconic {
+			box-sizing: border-box;
+			fill: #2293ec;
+			padding: 2px;
+			opacity: 0;
+			-ms-transform: scale(0);
+			transform: scale(0);
+			transition: opacity 0.2s cubic-bezier(0.51, 0.92, 0.24, 1), transform 0.2s cubic-bezier(0.51, 0.92, 0.24, 1);
+		}
+
+		.select {
+			position: relative;
+			margin: 1px 5px;
+			padding: 0;
+			width: 120px;
+			color: #fff;
+			border-radius: 3px;
+			border: 1px solid rgba(0, 0, 0, 0.2);
+			box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02);
+			font-size: 11px;
+			line-height: 16px;
+			overflow: hidden;
+			outline: 0;
+			vertical-align: middle;
+			background: rgba(0, 0, 0, 0.3);
+			display: inline-block;
+
+			select {
+				margin: 0;
+				padding: 4px 8px;
+				width: 120%;
+				color: #fff;
+				font-size: 11px;
+				line-height: 16px;
+				border: 0;
+				outline: 0;
+				box-shadow: none;
+				border-radius: 0;
+				background-color: transparent;
+				background-image: none;
+				-moz-appearance: none;
+				-webkit-appearance: none;
+				appearance: none;
+
+				option {
+					margin: 0;
+					padding: 0;
+					background: #fff;
+					color: #333;
+					transition: none;
+				}
+			}
+
+			select:disabled {
+				color: #000;
+				cursor: not-allowed;
+			}
+		}
+
+		.select::after {
+			position: absolute;
+			content: "≡";
+			right: 8px;
+			top: 4px;
+			color: #2293ec;
+			font-size: 16px;
+			line-height: 16px;
+			font-weight: 700;
+			pointer-events: none;
+		}
+
+		/* The switch - the box around the slider */
+		.switch {
+			position: relative;
+			display: inline-block;
+			width: 42px;
+			height: 22px;
+			bottom: -2px;
+			line-height: 24px;
+		}
+
+		/* Hide default HTML checkbox */
+		.switch input {
+			opacity: 0;
+			width: 0;
+			height: 0;
+		}
+
+		/* The slider */
+		.slider {
+			position: absolute;
+			cursor: pointer;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			border: 1px solid rgba(0, 0, 0, 0.2);
+			box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02);
+			background: rgba(0, 0, 0, 0.3);
+			-webkit-transition: 0.4s;
+			transition: 0.4s;
+
+			&:before {
+				position: absolute;
+				content: "";
+				height: 14px;
+				width: 14px;
+				left: 3px;
+				bottom: 3px;
+				background-color: $colorBlue;
+			}
+		}
+
+		input:checked + .slider {
+			background-color: $colorBlue;
+		}
+
+		input:checked + .slider:before {
+			-ms-transform: translateX(20px);
+			transform: translateX(20px);
+			background-color: #ffffff;
+		}
+
+		/* Rounded sliders */
+		.slider.round {
+			border-radius: 20px;
+		}
+
+		.slider.round:before {
+			border-radius: 50%;
 		}
 	}
-
-	.select::after {
-		position: absolute;
-		content: "≡";
-		right: 8px;
-		top: 4px;
-		color: #2293ec;
-		font-size: 16px;
-		line-height: 16px;
-		font-weight: 700;
-		pointer-events: none;
-	}
-
-	/* The switch - the box around the slider */
-	.switch {
-		position: relative;
-		display: inline-block;
-		width: 42px;
-		height: 22px;
-		bottom: 4px;
-	}
-
-	/* Hide default HTML checkbox */
-	.switch input {
-		opacity: 0;
-		width: 0;
-		height: 0;
-	}
-
-	/* The slider */
-	.slider {
-		position: absolute;
-		cursor: pointer;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		border: 1px solid rgba(0, 0, 0, 0.2);
-		box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02);
-		background: rgba(0, 0, 0, 0.3);
-		-webkit-transition: 0.4s;
-		transition: 0.4s;
-	}
-
-	.slider:before {
-		position: absolute;
-		content: "";
-		height: 14px;
-		width: 14px;
-		left: 3px;
-		bottom: 3px;
-		background-color: $colorBlue;
-		-webkit-transition: 0.4s;
-		transition: 0.4s;
-	}
-
-	input:checked + .slider {
-		background-color: $colorBlue;
-	}
-
-	input:checked + .slider:before {
-		-ms-transform: translateX(20px);
-		transform: translateX(20px);
-		background-color: #ffffff;
-	}
-
-	/* Rounded sliders */
-	.slider.round {
-		border-radius: 20px;
-	}
-
-	.slider.round:before {
-		border-radius: 50%;
-	}
-}
-
-#fullSettings {
-	width: 100%;
-	max-width: 700px;
-	margin-left: auto;
-	margin-right: auto;
 
 	.setting_category {
 		font-size: 20px;
@@ -315,6 +285,7 @@
 			color: #ccc;
 			display: inline-block;
 			width: 100%;
+			overflow-wrap: break-word;
 
 			a {
 				color: rgba(255, 255, 255, 0.9);
@@ -325,15 +296,15 @@
 			&:last-of-type {
 				margin: 0;
 			}
-		}
 
-		p.warning {
-			margin-bottom: 30px;
-			color: $colorRed;
-			font-weight: bold;
-			font-size: 18px;
-			text-align: justify;
-			line-height: 22px;
+			.warning {
+				margin-bottom: 30px;
+				color: $colorRed;
+				font-weight: bold;
+				font-size: 18px;
+				text-align: justify;
+				line-height: 22px;
+			}
 		}
 
 		span.text {
@@ -357,51 +328,14 @@
 		}
 
 		input.text {
-			padding: 9px 2px;
 			width: calc(50% - 4px);
-			background-color: transparent;
-			color: #fff;
-			border: none;
-			border-bottom: 1px solid #222;
-			border-radius: 0;
-			box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
-			outline: 0;
-
-			&:focus {
-				border-bottom-color: #2293ec;
-			}
-		}
-
-		input:hover {
-			border-bottom: #2293ec solid 1px;
-		}
-	}
-
-	.basicModal__button {
-		display: inline-block;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), inset 1px 0 0 rgba(0, 0, 0, 0.2);
-		width: 100%;
-		min-width: 50px;
-		border-radius: 5px;
-
-		&:hover {
-			cursor: pointer;
-		}
-	}
-
-	.basicModal__button_SAVE {
-		color: #b22027;
-
-		&:hover {
-			background: #b22027;
-			color: #ffffff;
 		}
 	}
 }
 
 // responsive web design for smaller screens
 @media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
-	.settings_view #fullSettings {
+	.settings_view {
 		max-width: 100%;
 
 		.setting_category {
@@ -437,34 +371,5 @@
 		.basicModal__button_SAVE {
 			margin-top: 20px;
 		}
-	}
-
-	.setLogin,
-	.setSorting,
-	.setDropBox,
-	.setLang,
-	.setLayout,
-	.setPublicSearch,
-	.setOverlay,
-	.setOverlayType,
-	.setMapDisplay,
-	.setMapDisplayPublic,
-	.setMapProvider,
-	.setMapIncludeSubalbums,
-	.setLocationDecoding,
-	.setLocationDecodingCachingType,
-	.setLocationShow,
-	.setLocationShowPublic,
-	.setDefaultLicense,
-	.setCSS,
-	.setNSFWVisible {
-		padding: 0;
-		font-size: 12px;
-	}
-
-	.settings_view {
-		width: 100%;
-		max-width: 100%;
-		padding: 20px 20px 0 20px;
 	}
 }

--- a/styles/main/_settings.scss
+++ b/styles/main/_settings.scss
@@ -401,6 +401,44 @@
 
 // responsive web design for smaller screens
 @media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.settings_view #fullSettings {
+		max-width: 100%;
+
+		.setting_category {
+			font-size: 14px;
+			padding-left: 0;
+			margin-bottom: 4px;
+		}
+
+		.setting_line {
+			font-size: 12px;
+
+			&:first-child {
+				padding-top: 20px;
+			}
+
+			p {
+				min-width: unset;
+				line-height: 20px;
+
+				&.warning {
+					font-size: 14px;
+					line-height: 16px;
+					margin-bottom: 0;
+				}
+
+				span,
+				input {
+					padding: 0;
+				}
+			}
+		}
+
+		.basicModal__button_SAVE {
+			margin-top: 20px;
+		}
+	}
+
 	.setLogin,
 	.setSorting,
 	.setDropBox,
@@ -427,6 +465,6 @@
 	.settings_view {
 		width: 100%;
 		max-width: 100%;
-		padding: 20px;
+		padding: 20px 20px 0 20px;
 	}
 }

--- a/styles/main/_settings.scss
+++ b/styles/main/_settings.scss
@@ -398,3 +398,35 @@
 		}
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.setLogin,
+	.setSorting,
+	.setDropBox,
+	.setLang,
+	.setLayout,
+	.setPublicSearch,
+	.setOverlay,
+	.setOverlayType,
+	.setMapDisplay,
+	.setMapDisplayPublic,
+	.setMapProvider,
+	.setMapIncludeSubalbums,
+	.setLocationDecoding,
+	.setLocationDecodingCachingType,
+	.setLocationShow,
+	.setLocationShowPublic,
+	.setDefaultLicense,
+	.setCSS,
+	.setNSFWVisible {
+		padding: 0;
+		font-size: 12px;
+	}
+
+	.settings_view {
+		width: 100%;
+		max-width: 100%;
+		padding: 20px;
+	}
+}

--- a/styles/main/_sharing.scss
+++ b/styles/main/_sharing.scss
@@ -1,5 +1,6 @@
 .sharing_view {
-	width: 600px;
+	width: 90%;
+	max-width: 700px;
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 20px;

--- a/styles/main/_sharing.scss
+++ b/styles/main/_sharing.scss
@@ -233,3 +233,31 @@
 		border: 1px solid $colorBlue;
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.sharing_view {
+		width: 100%;
+		max-width: 100%;
+		padding: 10px;
+
+		.select {
+			font-size: 12px;
+		}
+
+		.iconic {
+			margin-left: -4px; // help with centering
+		}
+	}
+
+	.sharing_view_line {
+		p {
+			width: 100%;
+		}
+
+		.basicModal__button {
+			width: 80%;
+			margin: 0 10%;
+		}
+	}
+}

--- a/styles/main/_sidebar.scss
+++ b/styles/main/_sidebar.scss
@@ -1,9 +1,9 @@
 .sidebar {
 	position: fixed;
-	top: 50px;
+	top: 49px;
 	right: -360px;
 	width: 350px;
-	height: calc(100% - 50px);
+	height: calc(100% - 49px);
 	background-color: rgba(25, 25, 25, 0.98);
 	border-left: 1px solid black(0.2);
 	transform: translateX(0);
@@ -228,6 +228,118 @@
 	.attr_location {
 		&.search {
 			cursor: pointer;
+		}
+	}
+}
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	// sidebar as overlay, small size
+	.sidebar {
+		width: 240px;
+		height: unset;
+		background-color: rgba(0, 0, 0, 0.6);
+
+		&__wrapper {
+			padding-bottom: 10px;
+		}
+
+		&__header {
+			height: 22px;
+
+			h1 {
+				margin: 6px 0;
+				font-size: 13px;
+			}
+		}
+
+		&__divider {
+			padding: 6px 0 2px;
+
+			h1 {
+				margin: 0 0 0 10px;
+				font-size: 12px;
+			}
+		}
+
+		table {
+			margin: 4px 0 6px 10px;
+			width: calc(100% - 16px);
+
+			tr td {
+				padding: 2px 0;
+				font-size: 11px;
+				line-height: 12px;
+
+				&:first-child {
+					width: 80px;
+				}
+			}
+		}
+
+		#tags {
+			margin: 4px 0 6px 10px;
+			width: calc(100% - 16px);
+
+			.empty {
+				margin: 0;
+				font-size: 11px;
+			}
+		}
+	}
+}
+
+@media only screen and (min-width: 568px) and (max-width: 768px),
+	only screen and (min-width: 568px) and (max-width: 640px) and (orientation: landscape) {
+	// sidebar on side, medium size
+	.sidebar {
+		width: 280px;
+
+		&__wrapper {
+			padding-bottom: 10px;
+		}
+
+		&__header {
+			height: 28px;
+
+			h1 {
+				margin: 8px 0;
+				font-size: 15px;
+			}
+		}
+
+		&__divider {
+			padding: 8px 0 4px;
+
+			h1 {
+				margin: 0 0 0 10px;
+				font-size: 13px;
+			}
+		}
+
+		table {
+			margin: 4px 0 6px 10px;
+			width: calc(100% - 16px);
+
+			tr td {
+				padding: 2px 0;
+				font-size: 12px;
+				line-height: 13px;
+
+				&:first-child {
+					width: 90px;
+				}
+			}
+		}
+
+		#tags {
+			margin: 4px 0 6px 10px;
+			width: calc(100% - 16px);
+
+			.empty {
+				margin: 0;
+				font-size: 12px;
+			}
 		}
 	}
 }

--- a/styles/main/_u2f.scss
+++ b/styles/main/_u2f.scss
@@ -1,5 +1,5 @@
 .u2f_view {
-	width: 80%;
+	width: 90%;
 	max-width: 700px;
 	margin-left: auto;
 	margin-right: auto;

--- a/styles/main/_u2f.scss
+++ b/styles/main/_u2f.scss
@@ -217,3 +217,23 @@
 		fill: #ffffff;
 	}
 }
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.u2f_view {
+		width: 100%;
+		max-width: 100%;
+		padding: 20px;
+	}
+
+	.u2f_view_line {
+		p {
+			width: 100%;
+		}
+
+		.basicModal__button_CREATE {
+			width: 80%;
+			margin: 0 10%;
+		}
+	}
+}

--- a/styles/main/_users.scss
+++ b/styles/main/_users.scss
@@ -1,5 +1,5 @@
 .users_view {
-	width: 80%;
+	width: 90%;
 	max-width: 700px;
 	margin-left: auto;
 	margin-right: auto;

--- a/styles/main/_users.scss
+++ b/styles/main/_users.scss
@@ -37,7 +37,7 @@
 
 	span.text {
 		display: inline-block;
-		padding: 9px 4px;
+		padding: 9px 6px 9px 0;
 		width: 40%;
 		//margin: 0 2%;
 		background-color: transparent;
@@ -46,18 +46,19 @@
 
 		&_icon {
 			width: 5%;
+			min-width: 32px;
 
 			.iconic {
 				width: 15px;
 				height: 14px;
-				margin: 0 15px 0 1px;
+				margin: 0 8px;
 				fill: #ffffff;
 			}
 		}
 	}
 
 	input.text {
-		padding: 9px 2px;
+		padding: 9px 6px 9px 0;
 		width: 40%;
 		//margin: 0 2%;
 		background-color: transparent;
@@ -67,7 +68,7 @@
 		border-radius: 0;
 		box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
 		outline: 0;
-		margin-bottom: 10px;
+		margin: 0 0 10px;
 
 		&:focus {
 			border-bottom-color: #2293ec;
@@ -87,6 +88,7 @@
 	.choice {
 		display: inline-block;
 		width: 5%;
+		min-width: 32px;
 		color: #fff;
 
 		input {
@@ -99,8 +101,7 @@
 			display: inline-block;
 			width: 16px;
 			height: 16px;
-			margin-top: 10px;
-			margin-left: 2px;
+			margin: 10px 8px 0;
 			background: rgba(0, 0, 0, 0.5);
 			border-radius: 3px;
 			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.7);
@@ -216,6 +217,32 @@
 			line-height: 16px;
 			font-weight: 700;
 			pointer-events: none;
+		}
+	}
+}
+
+// responsive web design for smaller screens
+@media only screen and (max-width: 567px), only screen and (max-width: 640px) and (orientation: portrait) {
+	.users_view {
+		width: 100%;
+		max-width: 100%;
+		padding: 20px;
+	}
+
+	.users_view_line {
+		p {
+			width: 100%;
+
+			.text,
+			input.text {
+				width: 36%;
+				font-size: smaller;
+			}
+		}
+		.choice {
+			// aligning elements is painful - should use table...
+			margin-left: -8px;
+			margin-right: 3px;
 		}
 	}
 }


### PR DESCRIPTION
This PR is an attempt at improving support for small screens in general and phones in particular. This adds responsive web design features to adjust the size of albums and photo thumbnails based on size of screen. It also adjusts margins and title size as well as suppresses subtitles to improve visibility of small thumbnails.

As an aside, I have some further ideas for improving the user experience on touch devices (for example, toggling the overlay on images doesn't seem to work for touch). Let me know if changes in this direction are of interest.