### PR TITLE
Refactor to use raw filesize

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1328,7 +1328,7 @@ album.updatePhoto = function (data) {
 				this.thumbUrl = data.thumbUrl;
 				this.thumb2x = data.thumb2x;
 				this.url = data.url;
-				this.size = data.size;
+				this.filesize = data.filesize;
 
 				view.album.content.updatePhoto(this);
 				albums.refresh();

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -458,8 +458,8 @@ lychee.locale = {
 	 * @return {string} A formatted and localized string
 	 */
 	printFilesizeLocalized: function( filesize ) {
-		console.assert(Number.isInteger(filesize), "printFilesizeLocalized: expedted integer, got %s", typeof filesize);
-		const suffix = [ ' B', 'kB', 'MB', 'GB' ];
+		console.assert(Number.isInteger(filesize), "printFilesizeLocalized: expected integer, got %s", typeof filesize);
+		const suffix = [ ' B', ' kB', ' MB', ' GB' ];
 		let i = 0;
 		// Sic! We check if the number is larger than 1000 but divide by 1024 by intention
 		// We aim at a number which has at most 3 non-decimal digits, i.e. the result shall be in the interval

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -451,4 +451,34 @@ lychee.locale = {
 	PHOTO_THUMB_HIDPI: "Square thumb HiDPI",
 	PHOTO_LIVE_VIDEO: "Video part of live-photo",
 	PHOTO_VIEW: "Lychee Photo View:",
+
+	/**
+	 * Formats a number representing a filesize in bytes as a localized string
+	 * @param {!number} filesize
+	 * @return {string} A formatted and localized string
+	 */
+	printFilesizeLocalized: function( filesize ) {
+		console.assert(Number.isInteger(filesize), "printFilesizeLocalized: expedted integer, got %s", typeof filesize);
+		const suffix = [ ' B', 'kB', 'MB', 'GB' ];
+		let i = 0;
+		// Sic! We check if the number is larger than 1000 but divide by 1024 by intention
+		// We aim at a number which has at most 3 non-decimal digits, i.e. the result shall be in the interval
+		// [1000/1024, 1000) = [0.977, 1000)  (lower bound included, upper bound excluded)
+		while( filesize >= 1000.0 && i < suffix.length) {
+			filesize = filesize / 1024.0;
+			i++;
+		}
+
+		// The number of decimal digits is anti-proportional to the number of non-decimal digits
+		// In total, there shall always be three digits
+		if( filesize >= 100.0 ) {
+			filesize = Math.round(filesize);
+		} else if( filesize >= 10.0 ) {
+			filesize = Math.round( filesize*10.0 ) / 10.0;
+		} else {
+			filesize = Math.round( filesize*100.0 ) / 100.0;
+		}
+
+		return Number( filesize ).toLocaleString() + suffix[i];
+	}
 };

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -957,7 +957,7 @@ photo.getArchive = function (photoIDs, kind = null) {
 		`;
 
 		if (myPhoto.url) {
-			msg += buildButton("FULL", `${lychee.locale["PHOTO_FULL"]} (${myPhoto.width}x${myPhoto.height}, ${myPhoto.size})`);
+			msg += buildButton("FULL", `${lychee.locale["PHOTO_FULL"]} (${myPhoto.width}x${myPhoto.height}, ${lychee.locale.printFilesizeLocalized(myPhoto.filesize)})`);
 		}
 		if (myPhoto.livePhotoUrl !== null) {
 			msg += buildButton("LIVEPHOTOVIDEO", `${lychee.locale["PHOTO_LIVE_VIDEO"]}`);

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -219,7 +219,7 @@ sidebar.createStructure.photo = function (data) {
 		title: lychee.locale[isVideo ? "PHOTO_VIDEO" : "PHOTO_IMAGE"],
 		type: sidebar.types.DEFAULT,
 		rows: [
-			{ title: lychee.locale["PHOTO_SIZE"], kind: "size", value: data.size },
+			{ title: lychee.locale["PHOTO_SIZE"], kind: "size", value: lychee.locale.printFilesizeLocalized(data.filesize) },
 			{ title: lychee.locale["PHOTO_FORMAT"], kind: "type", value: data.type },
 			{ title: lychee.locale["PHOTO_RESOLUTION"], kind: "resolution", value: data.width + " x " + data.height },
 		],


### PR DESCRIPTION
Changed frontend to use the JSON attribute `filesize` which reports the size of an photo in bytes. The filesize is converted to a localized string by the frontend.