### PR TITLE
Refactor timestamps anew

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -660,7 +660,7 @@ album.setSorting = function (albumID) {
 				<option value='id'>` +
 		lychee.locale["SORT_PHOTO_SELECT_1"] +
 		`</option>
-				<option value='takestamp'>` +
+				<option value='taken_at'>` +
 		lychee.locale["SORT_PHOTO_SELECT_2"] +
 		`</option>
 				<option value='title'>` +

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -94,7 +94,7 @@ albums._createSmartAlbums = function (data) {
 		data.unsorted = {
 			id: "unsorted",
 			title: lychee.locale["UNSORTED"],
-			sysdate: "",
+			created_at: null,
 			unsorted: "1",
 			thumb: data.unsorted.thumb,
 		};
@@ -104,7 +104,7 @@ albums._createSmartAlbums = function (data) {
 		data.starred = {
 			id: "starred",
 			title: lychee.locale["STARRED"],
-			sysdate: "",
+			created_at: null,
 			star: "1",
 			thumb: data.starred.thumb,
 		};
@@ -114,7 +114,7 @@ albums._createSmartAlbums = function (data) {
 		data.public = {
 			id: "public",
 			title: lychee.locale["PUBLIC"],
-			sysdate: "",
+			created_at: null,
 			public: "1",
 			visible: "0",
 			thumb: data.public.thumb,
@@ -125,7 +125,7 @@ albums._createSmartAlbums = function (data) {
 		data.recent = {
 			id: "recent",
 			title: lychee.locale["RECENT"],
-			sysdate: "",
+			created_at: null,
 			recent: "1",
 			thumb: data.recent.thumb,
 		};

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -59,7 +59,10 @@ build.getAlbumThumb = function (data) {
 };
 
 build.album = function (data, disabled = false) {
-	let subtitle = data.sysdate;
+	const formattedCreationTs = lychee.locale.printMonthYear(data.created_at);
+	const formattedMinTs = lychee.locale.printMonthYear(data.min_taken_at);
+	const formattedMaxTs = lychee.locale.printMonthYear(data.max_taken_at);
+	let subtitle = formattedCreationTs;
 
 	// check setting album_subtitle_type:
 	// takedate: date range (min/max_takedate from EXIF; if missing defaults to creation)
@@ -71,9 +74,9 @@ build.album = function (data, disabled = false) {
 			subtitle = data.description ? data.description : "";
 			break;
 		case "takedate":
-			if ((data.min_takestamp && data.min_takestamp !== "") || (data.max_takestamp && data.max_takestamp !== "")) {
-				// either min_takestamp or max_takestamp set and not null
-				subtitle = data.min_takestamp === data.max_takestamp ? data.max_takestamp : data.min_takestamp + " - " + data.max_takestamp;
+			if (formattedMinTs !== "" || formattedMaxTs !== "") {
+				// either min_taken_at or max_taken_at is set
+				subtitle = formattedMinTs === formattedMaxTs ? formattedMaxTs : formattedMinTs + " - " + formattedMaxTs;
 				subtitle = `<span title='Camera Date'>${build.iconic("camera-slr")}</span>${subtitle}`;
 				break;
 			}
@@ -82,15 +85,15 @@ build.album = function (data, disabled = false) {
 			break;
 		case "oldstyle":
 		default:
-			if (lychee.sortingAlbums !== "" && data.min_takestamp && data.max_takestamp) {
+			if (lychee.sortingAlbums !== "" && data.min_taken_at && data.max_taken_at) {
 				let sortingAlbums = lychee.sortingAlbums.replace("ORDER BY ", "").split(" ");
-				if (sortingAlbums[0] === "max_takestamp" || sortingAlbums[0] === "min_takestamp") {
-					if (data.min_takestamp !== "" && data.max_takestamp !== "") {
-						subtitle = data.min_takestamp === data.max_takestamp ? data.max_takestamp : data.min_takestamp + " - " + data.max_takestamp;
-					} else if (data.min_takestamp !== "" && sortingAlbums[0] === "min_takestamp") {
-						subtitle = data.min_takestamp;
-					} else if (data.max_takestamp !== "" && sortingAlbums[0] === "max_takestamp") {
-						subtitle = data.max_takestamp;
+				if (sortingAlbums[0] === "max_taken_at" || sortingAlbums[0] === "min_taken_at") {
+					if (formattedMinTs !== "" && formattedMaxTs !== "") {
+						subtitle = formattedMinTs === formattedMaxTs ? formattedMaxTs : formattedMinTs + " - " + formattedMaxTs;
+					} else if (formattedMinTs !== "" && sortingAlbums[0] === "min_taken_at") {
+						subtitle = formattedMinTs;
+					} else if (formattedMaxTs !== "" && sortingAlbums[0] === "max_taken_at") {
+						subtitle = formattedMaxTs;
 					}
 				}
 			}
@@ -230,8 +233,9 @@ build.photo = function (data, disabled = false) {
 					<h1 title='$${data.title}'>$${data.title}</h1>
 			`;
 
-	if (data.takedate !== "") html += lychee.html`<a><span title='Camera Date'>${build.iconic("camera-slr")}</span>${data.takedate}</a>`;
-	else html += lychee.html`<a>${data.sysdate}</a>`;
+	if (data.taken_at !== null)
+		html += lychee.html`<a><span title='Camera Date'>${build.iconic("camera-slr")}</span>${lychee.locale.printDateTime(data.taken_at)}</a>`;
+	else html += lychee.html`<a>${lychee.locale.printDateTime(data.created_at)}</a>`;
 
 	html += `</div>`;
 
@@ -272,9 +276,9 @@ build.overlay_image = function (data) {
 			overlay = data.description;
 			break;
 		case "date":
-			if (data.takedate && data.takedate !== "")
-				overlay = `<a><span title='Camera Date'>${build.iconic("camera-slr")}</span>${data.takedate}</a>`;
-			else overlay = data.sysdate;
+			if (data.taken_at != null)
+				overlay = `<a><span title='Camera Date'>${build.iconic("camera-slr")}</span>${lychee.locale.printDateTime(data.taken_at)}</a>`;
+			else overlay = lychee.locale.printDateTime(data.created_at);
 			break;
 		case "exif":
 			let exifHash = data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -481,4 +481,40 @@ lychee.locale = {
 
 		return Number(filesize).toLocaleString() + suffix[i];
 	},
+
+	/**
+	 * Converts a JSON encoded date/time into a localized string.
+	 *
+	 * The localized string uses the JS "medium" verbosity.
+	 * The precise definition of "medium verbosity" depends on the current locale, but for Western languages this
+	 * means that the date portion is fully printed with digits (e.g. something like 03/30/2021 for English,
+	 * 30/03/2021 for French and 30.03.2021 for German), and that the time portion is printed with a resolution of
+	 * seconds with two digits for all parts either in 24h or 12h scheme (e.g. something like 02:24:13pm for English
+	 * and 14:24:13 for French/German).
+	 *
+	 * @param {?string} jsonDateTime
+	 * @return {string} A formatted and localized time
+	 */
+	printDateTime: function (jsonDateTime) {
+		if (typeof jsonDateTime !== "string" || jsonDateTime === "") return "";
+		const locale = "default"; // use the user's browser settings
+		const format = { dateStyle: "medium", timeStyle: "medium" };
+		return new Date(jsonDateTime).toLocaleString(locale, format);
+	},
+
+	/**
+	 * Converts a JSON encoded date/time into a localized string which only displays month and year.
+	 *
+	 * The month is printed as a shortened word with 3/4 letters, the year is printed with 4 digits (e.g. something like
+	 * "Aug 2020" in English or "Août 2020" in French).
+	 *
+	 * @param {?string} jsonDateTime
+	 * @return {string} A formatted and localized month and year
+	 */
+	printMonthYear: function (jsonDateTime) {
+		if (typeof jsonDateTime !== "string" || jsonDateTime === "") return "";
+		const locale = "default"; // use the user's browser settings
+		const format = { month: "short", year: "numeric" };
+		return new Date(jsonDateTime).toLocaleDateString(locale, format);
+	},
 };

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -518,15 +518,15 @@ lychee.locale = {
 		// want to call `toLocalString` which is fine and don't do any time
 		// arithmetics.
 		// Then we add the original timezone to the string manually.
-		const splitDateTime = jsonDateTime.split(/([-Z+])/);
-		console.assert(splitDateTime.length === 3, "'jsonDateTime' is not formatted acc. to ISO 8601; passed string was: " + jsonDateTime);
+		const splitDateTime = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})([-Z+])(\d{2}:\d{2})?$/.exec(jsonDateTime);
+		console.assert(splitDateTime.length === 4, "'jsonDateTime' is not formatted acc. to ISO 8601; passed string was: " + jsonDateTime);
 		const locale = "default"; // use the user's browser settings
 		const format = { dateStyle: "medium", timeStyle: "medium" };
-		let result = new Date(splitDateTime[0]).toLocaleString(locale, format);
-		if (splitDateTime[1] === "Z" || splitDateTime[2] === "00:00") {
+		let result = new Date(splitDateTime[1]).toLocaleString(locale, format);
+		if (splitDateTime[2] === "Z" || splitDateTime[3] === "00:00") {
 			result += " UTC";
 		} else {
-			result += " UTC" + splitDateTime[1] + splitDateTime[2];
+			result += " UTC" + splitDateTime[2] + splitDateTime[3];
 		}
 		return result;
 	},

--- a/scripts/main/mapview.js
+++ b/scripts/main/mapview.js
@@ -125,8 +125,15 @@ mapview.open = function (albumID = null) {
 
 	// Define how the photos on the map should look like
 	mapview.photoLayer = L.photo.cluster().on("click", function (e) {
-		var photo = e.layer.photo;
-		var template = "";
+		const photo = {
+			photoID: e.layer.photo.photoID,
+			albumID: e.layer.photo.albumID,
+			name: e.layer.photo.name,
+			url: e.layer.photo.url,
+			url2x: e.layer.photo.url2x,
+			taken_at: lychee.locale.printDateTime(e.layer.photo.taken_at),
+		};
+		let template = "";
 
 		// Retina version if available
 		if (photo.url2x !== "") {
@@ -135,14 +142,14 @@ mapview.open = function (albumID = null) {
 				'srcset="{url} 1x, {url2x} 2x" ',
 				'data-album-id="{albumID}" data-id="{photoID}"/><div><h1>{name}</h1><span title="Camera Date">',
 				build.iconic("camera-slr"),
-				"</span><p>{takedate}</p></div>"
+				"</span><p>{taken_at}</p></div>"
 			);
 		} else {
 			template = template.concat(
 				'<img class="image-leaflet-popup" src="{url}" ',
 				'data-album-id="{albumID}" data-id="{photoID}"/><div><h1>{name}</h1><span title="Camera Date">',
 				build.iconic("camera-slr"),
-				"</span><p>{takedate}</p></div>"
+				"</span><p>{taken_at}</p></div>"
 			);
 		}
 
@@ -184,7 +191,7 @@ mapview.open = function (albumID = null) {
 					url: element.sizeVariants.small !== null ? element.sizeVariants.small.url : element.url,
 					url2x: element.sizeVariants.small2x !== null ? element.sizeVariants.small2x.url : null,
 					name: element.title,
-					takedate: element.takedate,
+					taken_at: element.taken_at,
 					albumID: element.album,
 					photoID: element.id,
 				});

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -76,8 +76,8 @@ photo.hasExif = function () {
 	return exifHash !== "";
 };
 
-photo.hasTakedate = function () {
-	return photo.json.takedate && photo.json.takedate !== "";
+photo.hasTakestamp = function () {
+	return photo.json.taken_at !== null;
 };
 
 photo.hasDesc = function () {

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -166,7 +166,7 @@ sidebar.createStructure.photo = function (data) {
 	if (data == null || data === "") return false;
 
 	let editable = typeof album !== "undefined" ? album.isUploadable() : false;
-	let exifHash = data.takedate + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
+	let exifHash = data.taken_at + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
 	let locationHash = data.longitude + data.latitude + data.altitude;
 	let structure = {};
 	let _public = "";
@@ -210,7 +210,7 @@ sidebar.createStructure.photo = function (data) {
 		type: sidebar.types.DEFAULT,
 		rows: [
 			{ title: lychee.locale["PHOTO_TITLE"], kind: "title", value: data.title, editable },
-			{ title: lychee.locale["PHOTO_UPLOADED"], kind: "uploaded", value: data.sysdate },
+			{ title: lychee.locale["PHOTO_UPLOADED"], kind: "uploaded", value: lychee.locale.printDateTime(data.created_at) },
 			{ title: lychee.locale["PHOTO_DESCRIPTION"], kind: "description", value: data.description, editable },
 		],
 	};
@@ -259,12 +259,12 @@ sidebar.createStructure.photo = function (data) {
 			type: sidebar.types.DEFAULT,
 			rows: isVideo
 				? [
-						{ title: lychee.locale["PHOTO_CAPTURED"], kind: "takedate", value: data.takedate },
+						{ title: lychee.locale["PHOTO_CAPTURED"], kind: "takedate", value: lychee.locale.printDateTime(data.taken_at) },
 						{ title: lychee.locale["PHOTO_MAKE"], kind: "make", value: data.make },
 						{ title: lychee.locale["PHOTO_TYPE"], kind: "model", value: data.model },
 				  ]
 				: [
-						{ title: lychee.locale["PHOTO_CAPTURED"], kind: "takedate", value: data.takedate },
+						{ title: lychee.locale["PHOTO_CAPTURED"], kind: "takedate", value: lychee.locale.printDateTime(data.taken_at) },
 						{ title: lychee.locale["PHOTO_MAKE"], kind: "make", value: data.make },
 						{ title: lychee.locale["PHOTO_TYPE"], kind: "model", value: data.model },
 						{ title: lychee.locale["PHOTO_LENS"], kind: "lens", value: data.lens },
@@ -457,7 +457,7 @@ sidebar.createStructure.album = function (album) {
 	structure.album = {
 		title: lychee.locale["ALBUM_ALBUM"],
 		type: sidebar.types.DEFAULT,
-		rows: [{ title: lychee.locale["ALBUM_CREATED"], kind: "created", value: data.sysdate }],
+		rows: [{ title: lychee.locale["ALBUM_CREATED"], kind: "created", value: lychee.locale.printDateTime(data.created_at) }],
 	};
 	if (data.albums && data.albums.length > 0) {
 		structure.album.rows.push({ title: lychee.locale["ALBUM_SUBALBUMS"], kind: "subalbums", value: data.albums.length });

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -985,10 +985,10 @@ view.settings = {
 						  <option value='public'>` +
 				lychee.locale["SORT_ALBUM_SELECT_4"] +
 				`</option>
-						  <option value='max_takestamp'>` +
+						  <option value='max_taken_at'>` +
 				lychee.locale["SORT_ALBUM_SELECT_5"] +
 				`</option>
-						  <option value='min_takestamp'>` +
+						  <option value='min_taken_at'>` +
 				lychee.locale["SORT_ALBUM_SELECT_6"] +
 				`</option>
 					  </select>
@@ -1018,7 +1018,7 @@ view.settings = {
 						  <option value='id'>` +
 				lychee.locale["SORT_PHOTO_SELECT_1"] +
 				`</option>
-						  <option value='takestamp'>` +
+						  <option value='taken_at'>` +
 				lychee.locale["SORT_PHOTO_SELECT_2"] +
 				`</option>
 						  <option value='title'>` +


### PR DESCRIPTION
This PR is a new attempt for the unfortunate, previous [PR #262](https://github.com/LycheeOrg/Lychee-front/pull/262).

Changes since the previous PR:

 - The method `lychee.locale.printDateTime` has been changed such that date/time strings are printed in localized format by with respect to the original timezone of the photo.