### PR TITLE
Rework scroll position saving

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -198,17 +198,6 @@ album.load = function (albumID, refresh = false) {
 			});
 		} else {
 			processData(data);
-			// save scroll position for this URL
-			if (data && data.albums && data.albums.length > 0) {
-				setTimeout(function () {
-					let urls = JSON.parse(localStorage.getItem("scroll"));
-					let urlWindow = window.location.href;
-
-					if (urls != null && urls[urlWindow]) {
-						$(window).scrollTop(urls[urlWindow]);
-					}
-				}, 500);
-			}
 
 			tabindex.makeFocusable(lychee.content);
 

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -350,8 +350,7 @@ $(document).ready(function () {
 	$("#sensitive_warning").on("click", view.album.nsfw_warning.next);
 
 	const rememberScrollPage = function (scrollPos) {
-		// only for albums with subalbums
-		if (album && album.json && album.json.albums && album.json.albums.length > 0) {
+		if (visible.albums() || visible.album()) {
 			let urls = JSON.parse(localStorage.getItem("scroll"));
 			if (urls == null || urls.length < 1) {
 				urls = {};

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -350,7 +350,7 @@ $(document).ready(function () {
 	$("#sensitive_warning").on("click", view.album.nsfw_warning.next);
 
 	const rememberScrollPage = function (scrollPos) {
-		if (visible.albums() || visible.album()) {
+		if ((visible.albums() && !visible.search()) || visible.album()) {
 			let urls = JSON.parse(localStorage.getItem("scroll"));
 			if (urls == null || urls.length < 1) {
 				urls = {};

--- a/scripts/main/search.js
+++ b/scripts/main/search.js
@@ -83,6 +83,8 @@ search.find = function (term) {
 								lychee.animate(lychee.content, "contentZoomIn");
 							}
 							lychee.setTitle(lychee.locale["SEARCH_RESULTS"], false);
+
+							$(window).scrollTop(0);
 						}, 300);
 					}
 				});

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -25,8 +25,6 @@ view.albums = {
 	},
 
 	content: {
-		scrollPosition: 0,
-
 		init: function () {
 			let smartData = "";
 			let albumsData = "";
@@ -100,10 +98,11 @@ view.albums = {
 			}
 
 			album.apply_nsfw_filter();
+
 			// Restore scroll position
-			if (view.albums.content.scrollPosition != null && view.albums.content.scrollPosition !== 0) {
-				$(document).scrollTop(view.albums.content.scrollPosition);
-			}
+			let urls = JSON.parse(localStorage.getItem("scroll"));
+			let urlWindow = window.location.href;
+			$(window).scrollTop((urls != null && urls[urlWindow]) ? urls[urlWindow] : 0);
 		},
 
 		title: function (albumID) {
@@ -229,15 +228,16 @@ view.album = {
 			}
 			html += photosData;
 
-			// Save and reset scroll position
-			view.albums.content.scrollPosition = $(document).scrollTop();
-			requestAnimationFrame(() => $(document).scrollTop(0));
-
 			// Add photos to view
 			lychee.content.html(html);
 			album.apply_nsfw_filter();
 
 			view.album.content.justify();
+
+			// Restore scroll position
+			let urls = JSON.parse(localStorage.getItem("scroll"));
+			let urlWindow = window.location.href;
+			$(window).scrollTop((urls != null && urls[urlWindow]) ? urls[urlWindow] : 0);
 		},
 
 		title: function (photoID) {

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -102,7 +102,7 @@ view.albums = {
 			// Restore scroll position
 			let urls = JSON.parse(localStorage.getItem("scroll"));
 			let urlWindow = window.location.href;
-			$(window).scrollTop((urls != null && urls[urlWindow]) ? urls[urlWindow] : 0);
+			$(window).scrollTop(urls != null && urls[urlWindow] ? urls[urlWindow] : 0);
 		},
 
 		title: function (albumID) {
@@ -237,7 +237,7 @@ view.album = {
 			// Restore scroll position
 			let urls = JSON.parse(localStorage.getItem("scroll"));
 			let urlWindow = window.location.href;
-			$(window).scrollTop((urls != null && urls[urlWindow]) ? urls[urlWindow] : 0);
+			$(window).scrollTop(urls != null && urls[urlWindow] ? urls[urlWindow] : 0);
 		},
 
 		title: function (photoID) {


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1027

This is essentially a cleanup of #230, which was restricted to albums with subalbums, as well as of some old code dating presumably to v3.

The bug in https://github.com/LycheeOrg/Lychee/issues/1027 was I believe due to a race condition between two callbacks with timeouts in `album.js`: one loading the content, the other restoring the scroll position. I solved that by moving the restoring code to `view.js` (where it gets invoked from the content loading callback).

In the process I noticed that there were two different versions of scroll position restoring code: one for the top level albums view (probably an old code dating back to v3), and another for albums with subalbums (from #230). We also didn't save the scroll position of albums without subalbums, which would trigger https://github.com/LycheeOrg/Lychee/issues/1027 as well. So I generalized the code to handle (hopefully) all cases: now the positions of all albums should be preserved, including the top level view and albums without subalbums.