### PR TITLE
Remove erroneously left v3 code

### DIFF
--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -413,14 +413,7 @@ photo.copyTo = function (photoIDs, albumID) {
 		if (data !== true) {
 			lychee.error(null, params, data);
 		} else {
-			if (albumID === album.getID()) {
-				album.reload();
-			} else {
-				// Lychee v3 does not support the albumID argument to
-				// Photo::duplicate so we need to do it manually, which is
-				// imperfect, as it moves the source photos, not the duplicates.
-				photo.setAlbum(photoIDs, albumID);
-			}
+			album.reload();
 		}
 	});
 };


### PR DESCRIPTION
Fixes "Copy To..." functionality

This was broken in #257. Basically, the front end had two implementations of this functionality: one for v3 and one for v4. Erroneously, instead of removing the v3 implementation, it became the default. As a result, _Copy To_ would create a duplicate in the destination album _and_ move the source photo(s) to that album as well.