### PR TITLE
Remember user preference for the visibility of the "about" panel

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -60,7 +60,7 @@ header.bind = function () {
 		multiselect.bind();
 		lychee.load();
 	});
-	header.dom("#button_info_album").on(eventName, function () { 
+	header.dom("#button_info_album").on(eventName, function () {
             sidebar.toggle(true)
         });
 	header.dom("#button_info").on(eventName, function () {

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -60,8 +60,12 @@ header.bind = function () {
 		multiselect.bind();
 		lychee.load();
 	});
-	header.dom("#button_info_album").on(eventName, sidebar.toggle);
-	header.dom("#button_info").on(eventName, sidebar.toggle);
+	header.dom("#button_info_album").on(eventName, function () { 
+            sidebar.toggle(true)
+        });
+	header.dom("#button_info").on(eventName, function () {
+            sidebar.toggle(true)
+        });
 	header.dom(".button--map-albums").on(eventName, function () {
 		lychee.gotoMap();
 	});

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -354,6 +354,8 @@ header.setMode = function (mode) {
 				);
 			} else if (album.isTagAlbum()) {
 				$("#button_info_album").show();
+                                if (sidebar.userPreferenceVisibility() && !visible.sidebar())
+                                    sidebar.toggle(false);
 				$("#button_move_album").hide();
 				$(".button_add, .header__divider", ".header__toolbar--album").hide();
 				tabindex.makeFocusable($("#button_info_album"));
@@ -375,6 +377,8 @@ header.setMode = function (mode) {
 				}
 			} else {
 				$("#button_info_album").show();
+                                if (sidebar.userPreferenceVisibility() && !visible.sidebar())
+                                    sidebar.toggle(false);
 				tabindex.makeFocusable($("#button_info_album"));
 				if (album.isUploadable()) {
 					$(

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -354,7 +354,7 @@ header.setMode = function (mode) {
 				);
 			} else if (album.isTagAlbum()) {
 				$("#button_info_album").show();
-				if (sidebar.userPreferenceVisibility() && !visible.sidebar()) sidebar.toggle(false);
+				if (sidebar.keepSidebarVisible() && !visible.sidebar()) sidebar.toggle(false);
 				$("#button_move_album").hide();
 				$(".button_add, .header__divider", ".header__toolbar--album").hide();
 				tabindex.makeFocusable($("#button_info_album"));
@@ -376,7 +376,7 @@ header.setMode = function (mode) {
 				}
 			} else {
 				$("#button_info_album").show();
-				if (sidebar.userPreferenceVisibility() && !visible.sidebar()) sidebar.toggle(false);
+				if (sidebar.keepSidebarVisible() && !visible.sidebar()) sidebar.toggle(false);
 				tabindex.makeFocusable($("#button_info_album"));
 				if (album.isUploadable()) {
 					$(

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -61,11 +61,11 @@ header.bind = function () {
 		lychee.load();
 	});
 	header.dom("#button_info_album").on(eventName, function () {
-            sidebar.toggle(true)
-        });
+		sidebar.toggle(true);
+	});
 	header.dom("#button_info").on(eventName, function () {
-            sidebar.toggle(true)
-        });
+		sidebar.toggle(true);
+	});
 	header.dom(".button--map-albums").on(eventName, function () {
 		lychee.gotoMap();
 	});
@@ -354,8 +354,7 @@ header.setMode = function (mode) {
 				);
 			} else if (album.isTagAlbum()) {
 				$("#button_info_album").show();
-                                if (sidebar.userPreferenceVisibility() && !visible.sidebar())
-                                    sidebar.toggle(false);
+				if (sidebar.userPreferenceVisibility() && !visible.sidebar()) sidebar.toggle(false);
 				$("#button_move_album").hide();
 				$(".button_add, .header__divider", ".header__toolbar--album").hide();
 				tabindex.makeFocusable($("#button_info_album"));
@@ -377,8 +376,7 @@ header.setMode = function (mode) {
 				}
 			} else {
 				$("#button_info_album").show();
-                                if (sidebar.userPreferenceVisibility() && !visible.sidebar())
-                                    sidebar.toggle(false);
+				if (sidebar.userPreferenceVisibility() && !visible.sidebar()) sidebar.toggle(false);
 				tabindex.makeFocusable($("#button_info_album"));
 				if (album.isUploadable()) {
 					$(

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -116,7 +116,7 @@ $(document).ready(function () {
 		})
 		.bind(["i", "ContextMenu"], function () {
 			if (!visible.multiselect()) {
-				sidebar.toggle();
+				sidebar.toggle(true);
 				return false;
 			}
 		})

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -435,7 +435,7 @@ lychee.load = function (autoplay = true) {
 
 			// Show Album -> it's below the map
 			if (visible.photo()) view.photo.hide();
-			if (visible.sidebar()) sidebar.toggle();
+			if (visible.sidebar()) sidebar.toggle(false);
 			if (album.json && albumID === album.json.id) {
 				view.album.title();
 			}
@@ -503,7 +503,7 @@ lychee.load = function (autoplay = true) {
 
 			// Show Album -> it's below the map
 			if (visible.photo()) view.photo.hide();
-			if (visible.sidebar()) sidebar.toggle();
+			if (visible.sidebar()) sidebar.toggle(false);
 			mapview.open();
 			lychee.footer_hide();
 		} else if (albumID == "search") {
@@ -519,7 +519,7 @@ lychee.load = function (autoplay = true) {
 				tabindex.makeUnfocusable(lychee.imageview);
 			}
 			if (visible.mapview()) mapview.close();
-			if (visible.sidebar() && album.isSmartID(albumID)) sidebar.toggle();
+			if (visible.sidebar() && album.isSmartID(albumID)) sidebar.toggle(false);
 			$("#sensitive_warning").hide();
 			if (album.json && albumID === album.json.id) {
 				view.album.title();
@@ -543,7 +543,7 @@ lychee.load = function (autoplay = true) {
 		photo.json = null;
 
 		// Hide sidebar
-		if (visible.sidebar()) sidebar.toggle();
+		if (visible.sidebar()) sidebar.toggle(false);
 
 		// Show Albums
 		if (visible.photo()) {

--- a/scripts/main/search.js
+++ b/scripts/main/search.js
@@ -69,7 +69,7 @@ search.find = function (term) {
 
 						setTimeout(() => {
 							if (visible.photo()) view.photo.hide();
-							if (visible.sidebar()) sidebar.toggle();
+							if (visible.sidebar()) sidebar.toggle(false);
 							if (visible.mapview()) mapview.close();
 
 							header.setMode("albums");

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -107,7 +107,7 @@ sidebar.triggerSearch = function (search_string) {
 	lychee.goto("search/" + encodeURIComponent(search_string));
 };
 
-sidebar.userPreferenceVisibility = function () {
+sidebar.keepSidebarVisible() = function () {
 	let v = sessionStorage.getItem("keepSidebarVisible");
 	return v !== null ? v === "true" : false;
 };

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -108,7 +108,7 @@ sidebar.triggerSearch = function (search_string) {
 };
 
 sidebar.userPreferenceVisibility = function () {
-	let v = sessionStorage.getItem("sidebarUserPreferenceVisible");
+	let v = sessionStorage.getItem("keepSidebarVisible");
 	return v !== null ? v === "true" : false;
 };
 
@@ -121,7 +121,7 @@ sidebar.toggle = function (is_user_initiated) {
 		sidebar.dom().toggleClass("active");
 		photo.updateSizeLivePhotoDuringAnimation();
 
-		if (is_user_initiated) sessionStorage.setItem("sidebarUserPreferenceVisible", visible.sidebar());
+		if (is_user_initiated) sessionStorage.setItem("keepSidebarVisible", visible.sidebar());
 
 		return true;
 	}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -107,10 +107,10 @@ sidebar.triggerSearch = function (search_string) {
 	lychee.goto("search/" + encodeURIComponent(search_string));
 };
 
-sidebar.userPreferenceVisibility = function() {
-        let v = sessionStorage.getItem("sidebarUserPreferenceVisible");
-        return v !== null ? v === "true" : false;
-}
+sidebar.userPreferenceVisibility = function () {
+	let v = sessionStorage.getItem("sidebarUserPreferenceVisible");
+	return v !== null ? v === "true" : false;
+};
 
 sidebar.toggle = function (is_user_initiated) {
 	if (visible.sidebar() || visible.sidebarbutton()) {
@@ -121,8 +121,7 @@ sidebar.toggle = function (is_user_initiated) {
 		sidebar.dom().toggleClass("active");
 		photo.updateSizeLivePhotoDuringAnimation();
 
-                if (is_user_initiated)
-                    sessionStorage.setItem("sidebarUserPreferenceVisible", visible.sidebar());
+		if (is_user_initiated) sessionStorage.setItem("sidebarUserPreferenceVisible", visible.sidebar());
 
 		return true;
 	}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -107,7 +107,7 @@ sidebar.triggerSearch = function (search_string) {
 	lychee.goto("search/" + encodeURIComponent(search_string));
 };
 
-sidebar.keepSidebarVisible() = function () {
+sidebar.keepSidebarVisible = function () {
 	let v = sessionStorage.getItem("keepSidebarVisible");
 	return v !== null ? v === "true" : false;
 };

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -108,8 +108,8 @@ sidebar.triggerSearch = function (search_string) {
 };
 
 sidebar.userPreferenceVisibility = function() {
-        let v = sessionStorage.getItem("sidebarUserToggled");
-        return v != null ? v : false;
+        let v = sessionStorage.getItem("sidebarUserPreferenceVisible");
+        return v !== null ? v === "true" : false;
 }
 
 sidebar.toggle = function (is_user_initiated) {
@@ -122,7 +122,7 @@ sidebar.toggle = function (is_user_initiated) {
 		photo.updateSizeLivePhotoDuringAnimation();
 
                 if (is_user_initiated)  
-                    sessionStorage.setItem("sidebarUserToggled", visible.sidebar());
+                    sessionStorage.setItem("sidebarUserPreferenceVisible", visible.sidebar());
 
 		return true;
 	}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -107,7 +107,12 @@ sidebar.triggerSearch = function (search_string) {
 	lychee.goto("search/" + encodeURIComponent(search_string));
 };
 
-sidebar.toggle = function () {
+sidebar.userPreferenceVisibility = function() {
+        let v = sessionStorage.getItem("sidebarUserToggled");
+        return v != null ? v : false;
+}
+
+sidebar.toggle = function (is_user_initiated) {
 	if (visible.sidebar() || visible.sidebarbutton()) {
 		header.dom(".button--info").toggleClass("active");
 		lychee.content.toggleClass("content--sidebar");
@@ -115,6 +120,9 @@ sidebar.toggle = function () {
 		if (typeof view !== "undefined") view.album.content.justify();
 		sidebar.dom().toggleClass("active");
 		photo.updateSizeLivePhotoDuringAnimation();
+
+                if (is_user_initiated)  
+                    sessionStorage.setItem("sidebarUserToggled", visible.sidebar());
 
 		return true;
 	}

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -121,7 +121,7 @@ sidebar.toggle = function (is_user_initiated) {
 		sidebar.dom().toggleClass("active");
 		photo.updateSizeLivePhotoDuringAnimation();
 
-                if (is_user_initiated)  
+                if (is_user_initiated)
                     sessionStorage.setItem("sidebarUserPreferenceVisible", visible.sidebar());
 
 		return true;

--- a/scripts/view/main.js
+++ b/scripts/view/main.js
@@ -172,7 +172,9 @@ $(document).ready(function () {
 	});
 
 	// Infobox
-	header.dom("#button_info").on("click", sidebar.toggle);
+	header.dom("#button_info").on("click", function () {
+            sidebar.toggle(true)
+        });
 
 	// Load photo
 	loadPhotoInfo(photoID);

--- a/scripts/view/main.js
+++ b/scripts/view/main.js
@@ -173,8 +173,8 @@ $(document).ready(function () {
 
 	// Infobox
 	header.dom("#button_info").on("click", function () {
-            sidebar.toggle(true)
-        });
+		sidebar.toggle(true);
+	});
 
 	// Load photo
 	loadPhotoInfo(photoID);


### PR DESCRIPTION
> Possible fix for https://github.com/LycheeOrg/Lychee/issues/653

## Main goal

This PR brings an enhancement to the front-end: remembering if the user wants to have the "about" panel open or not.

### Current behavior

1.  Open an album or a photo
2. Click on the "info" button or press the `i` key
3. Go back to a view where the "about" panel can't be shown
4. Open an album or a photo
5. The "about" panel is always closed, regardless of its last user-set state

### Aimed behavior

1.  Open an album or a photo
2. Click on the "info" button or press the `i` key
3. Go back to a view where the "about" panel can't be shown
4. Open an album or a photo
5. The "about" panel is closed or open, based on the last user choice

## How it is achieved

In this PR, a solution is proposed.

- We should distinguish whether or not toggling the "about" panel visibility is user-generated or not
    - In order to do that, a parameter has been added to the `sidebar.toggle` method: `is_user_initiated`
- We should save the fact that the user toggled the "about" panel visibility
    - Whenever the toggling is user-generated, this visibility status is saved in the `SessionStorage`, so the status is Session-dependent, and is forgotten once the browser is closed. If needed it could be stored in the `LocalStorage`, to keep it persistent after browser restarts.
- We should open the "about" panel based on the user's last saved preference
    - When the "about" button is showed, it is checked whether or not the user had the panel previously open, and if yes, open it automatically if it's not already visible
- By default, the about panel is kept closed, no change compared to current way of doing it.

## Things to discuss and TODOs

- [x] `SessionStorage` or `LocalStorage`?
- [x] Key name: is `sidebarUserPreferenceVisible` a good name or not? And if not, what to choose?