### PR TITLE
Fix menus

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -37,7 +37,7 @@ contextMenu.add = function (e) {
 			// For tag albums the context menu is normally not used.
 			items = [];
 		}
-		if (albumID !== "starred" && albumID !== "public" && albumID !== "recent") {
+		if (Number.isInteger(parseInt(albumID)) || albumID === "unsorted") {
 			if (albumID !== "unsorted") {
 				let button_visibility_album = $("#button_visibility_album");
 				if (button_visibility_album && button_visibility_album.css("display") === "none") {

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -446,10 +446,12 @@ contextMenu.photoMore = function (photoID, e) {
 			});
 		}
 		/* The condition below is copied from view.photo.header() */
-		if (!(
-			(photo.json.type && (photo.json.type.indexOf("video") === 0 || photo.json.type === "raw")) ||
-			(photo.json.livePhotoUrl !== "" && photo.json.livePhotoUrl !== null)
-		)) {
+		if (
+			!(
+				(photo.json.type && (photo.json.type.indexOf("video") === 0 || photo.json.type === "raw")) ||
+				(photo.json.livePhotoUrl !== "" && photo.json.livePhotoUrl !== null)
+			)
+		) {
 			let button_rotate_cwise = $("#button_rotate_cwise");
 			if (button_rotate_cwise && button_rotate_cwise.css("display") === "none") {
 				items.unshift({

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -350,17 +350,24 @@ header.setMode = function (mode) {
 				);
 			} else if (album.isTagAlbum()) {
 				$("#button_info_album").show();
-				$("#button_nsfw_album, #button_move_album").hide();
+				$("#button_move_album").hide();
 				$(".button_add, .header__divider", ".header__toolbar--album").hide();
 				tabindex.makeFocusable($("#button_info_album"));
-				tabindex.makeUnfocusable($("#button_nsfw_album, #button_move_album"));
+				tabindex.makeUnfocusable($("#button_move_album"));
 				tabindex.makeUnfocusable($(".button_add, .header__divider", ".header__toolbar--album"));
 				if (album.isUploadable()) {
-					$("#button_visibility_album, #button_sharing_album_users, #button_trash_album").show();
-					tabindex.makeFocusable($("#button_visibility_album, #button_sharing_album_users, #button_trash_album"));
+					$("#button_nsfw_album, #button_visibility_album, #button_sharing_album_users, #button_trash_album").show();
+					tabindex.makeFocusable($("#button_nsfw_album, #button_visibility_album, #button_sharing_album_users, #button_trash_album"));
+					if ($("#button_visibility_album").is(":hidden")) {
+						// This can happen with narrow screens.  In that
+						// case we re-enable the add button which will
+						// contain the overflow items.
+						$(".button_add, .header__divider", ".header__toolbar--album").show();
+						tabindex.makeFocusable($(".button_add, .header__divider", ".header__toolbar--album"));
+					}
 				} else {
-					$("#button_visibility_album, #button_sharing_album_users, #button_trash_album").hide();
-					tabindex.makeUnfocusable($("#button_visibility_album, #button_sharing_album_users, #button_trash_album"));
+					$("#button_nsfw_album, #button_visibility_album, #button_sharing_album_users, #button_trash_album").hide();
+					tabindex.makeUnfocusable($("#button_nsfw_album, #button_visibility_album, #button_sharing_album_users, #button_trash_album"));
 				}
 			} else {
 				$("#button_info_album").show();

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -105,7 +105,7 @@ upload.start = {
 
 				albums.refresh();
 
-				if (album.getID() === false) lychee.goto("unsorted");
+				if (album.getID() === false) lychee.goto();
 				else album.load(albumID);
 			};
 
@@ -321,7 +321,7 @@ upload.start = {
 
 						albums.refresh();
 
-						if (album.getID() === false) lychee.goto("0");
+						if (album.getID() === false) lychee.goto();
 						else album.load(albumID);
 					});
 				});
@@ -505,7 +505,7 @@ upload.start = {
 								encounteredProblems ? lychee.locale["UPLOAD_COMPLETE_FAILED"] : null
 							);
 
-							if (album.getID() === false) lychee.goto("0");
+							if (album.getID() === false) lychee.goto();
 							else album.load(albumID);
 
 							if (encounteredProblems) showCloseButton();
@@ -554,7 +554,7 @@ upload.start = {
 								albums.refresh();
 								upload.notify(lychee.locale["UPLOAD_COMPLETE"], lychee.locale["UPLOAD_COMPLETE_FAILED"]);
 
-								if (album.getID() === false) lychee.goto("0");
+								if (album.getID() === false) lychee.goto();
 								else album.load(albumID);
 
 								showCloseButton();
@@ -709,7 +709,7 @@ upload.start = {
 
 					albums.refresh();
 
-					if (album.getID() === false) lychee.goto("0");
+					if (album.getID() === false) lychee.goto();
 					else album.load(albumID);
 				});
 			});

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -578,7 +578,7 @@ view.album = {
 	},
 
 	sidebar: function () {
-		if ((visible.album() || (album.json && album.json.init)) && !visible.photo()) {
+		if ((visible.album() || (album.json && !album.json.init)) && !visible.photo()) {
 			let structure = sidebar.createStructure.album(album);
 			let html = sidebar.render(structure);
 
@@ -846,6 +846,7 @@ view.photo = {
 	},
 
 	header: function () {
+		/* Note: the condition below is duplicated in contextMenu.photoMore() */
 		if (
 			(photo.json.type && (photo.json.type.indexOf("video") === 0 || photo.json.type === "raw")) ||
 			(photo.json.livePhotoUrl !== "" && photo.json.livePhotoUrl !== null)


### PR DESCRIPTION
OK, here is the patch that fixes the menus that I would like us to merge before the next stable release. As usual, once I started poking around all sort of other minor irritations showed up so I included a few other fixes as well. But in general:

* Removed Import and New Album from smart albums (kept Upload since that one at least works)
* Fixed the code introduced in #253 that moves some of the button functions to the context menu on narrow screens. It added them unconditionally, even if the particular functionality shouldn't have been available (either due to the public mode or smart or tag albums)
* Removed cover image selection entry from the context menu for smart and tag albums since it doesn't work there
* NSFW button was not available for tag albums even though it does work there
* Import via GUI in albums view would often try to load non-existent album "0" when finished. I could've changed it to "unsorted" but I think it's better to simply reload the albums view since that's where the user was to begin with.
* Under unclear circumstances (race condition?), the info sidebar could be empty for albums. Turns out there was already code in place to handle that but a condition got reversed in #253, presumably accidentally.