### PR TITLE
Use filesize in original size variant - see Lychee PR #1239

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1286,7 +1286,6 @@ album.updatePhoto = function (data) {
 	if (album.json) {
 		$.each(album.json.photos, function () {
 			if (this.id === data.id) {
-				this.filesize = data.filesize;
 				// Deep copy size variants
 				this.size_variants = {
 					thumb: null,

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1280,6 +1280,7 @@ album.updatePhoto = function (data) {
 		result.url = src.url;
 		result.width = src.width;
 		result.height = src.height;
+		result.filesize = src.filesize;
 		return result;
 	};
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -945,9 +945,8 @@ photo.getArchive = function (photoIDs, kind = null) {
 		if (myPhoto.size_variants.original.url) {
 			msg += buildButton(
 				"FULL",
-				`${lychee.locale["PHOTO_FULL"]} (${myPhoto.size_variants.original.width}x${
-					myPhoto.size_variants.original.height
-				}, ${lychee.locale.printFilesizeLocalized(myPhoto.filesize)})`
+				`${lychee.locale["PHOTO_FULL"]} (${myPhoto.size_variants.original.width}x${myPhoto.size_variants.original.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.original.filesize)})`
 			);
 		}
 		if (myPhoto.live_photo_url !== null) {
@@ -956,37 +955,43 @@ photo.getArchive = function (photoIDs, kind = null) {
 		if (myPhoto.size_variants.medium2x !== null) {
 			msg += buildButton(
 				"MEDIUM2X",
-				`${lychee.locale["PHOTO_MEDIUM_HIDPI"]} (${myPhoto.size_variants.medium2x.width}x${myPhoto.size_variants.medium2x.height})`
+				`${lychee.locale["PHOTO_MEDIUM_HIDPI"]} (${myPhoto.size_variants.medium2x.width}x${myPhoto.size_variants.medium2x.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.medium2x.filesize)})`
 			);
 		}
 		if (myPhoto.size_variants.medium !== null) {
 			msg += buildButton(
 				"MEDIUM",
-				`${lychee.locale["PHOTO_MEDIUM"]} (${myPhoto.size_variants.medium.width}x${myPhoto.size_variants.medium.height})`
+				`${lychee.locale["PHOTO_MEDIUM"]} (${myPhoto.size_variants.medium.width}x${myPhoto.size_variants.medium.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.medium.filesize)})`
 			);
 		}
 		if (myPhoto.size_variants.small2x !== null) {
 			msg += buildButton(
 				"SMALL2X",
-				`${lychee.locale["PHOTO_SMALL_HIDPI"]} (${myPhoto.size_variants.small2x.width}x${myPhoto.size_variants.small2x.height})`
+				`${lychee.locale["PHOTO_SMALL_HIDPI"]} (${myPhoto.size_variants.small2x.width}x${myPhoto.size_variants.small2x.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.small2x.filesize)})`
 			);
 		}
 		if (myPhoto.size_variants.small !== null) {
 			msg += buildButton(
 				"SMALL",
-				`${lychee.locale["PHOTO_SMALL"]} (${myPhoto.size_variants.small.width}x${myPhoto.size_variants.small.height})`
+				`${lychee.locale["PHOTO_SMALL"]} (${myPhoto.size_variants.small.width}x${myPhoto.size_variants.small.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.small.filesize)})`
 			);
 		}
 		if (myPhoto.size_variants.thumb2x !== null) {
 			msg += buildButton(
 				"THUMB2X",
-				`${lychee.locale["PHOTO_THUMB_HIDPI"]} (${myPhoto.size_variants.thumb2x.width}x${myPhoto.size_variants.thumb2x.height})`
+				`${lychee.locale["PHOTO_THUMB_HIDPI"]} (${myPhoto.size_variants.thumb2x.width}x${myPhoto.size_variants.thumb2x.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.thumb2x.filesize)})`
 			);
 		}
 		if (myPhoto.size_variants.thumb !== null) {
 			msg += buildButton(
 				"THUMB",
-				`${lychee.locale["PHOTO_THUMB"]} (${myPhoto.size_variants.thumb.width}x${myPhoto.size_variants.thumb.height})`
+				`${lychee.locale["PHOTO_THUMB"]} (${myPhoto.size_variants.thumb.width}x${myPhoto.size_variants.thumb.height},
+				${lychee.locale.printFilesizeLocalized(myPhoto.size_variants.thumb.filesize})`
 			);
 		}
 

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -226,7 +226,7 @@ sidebar.createStructure.photo = function (data) {
 		title: lychee.locale[isVideo ? "PHOTO_VIDEO" : "PHOTO_IMAGE"],
 		type: sidebar.types.DEFAULT,
 		rows: [
-			{ title: lychee.locale["PHOTO_SIZE"], kind: "size", value: lychee.locale.printFilesizeLocalized(data.filesize) },
+			{ title: lychee.locale["PHOTO_SIZE"], kind: "size", value: lychee.locale.printFilesizeLocalized(data.size_variants.original.filesize) },
 			{ title: lychee.locale["PHOTO_FORMAT"], kind: "type", value: data.type },
 			{
 				title: lychee.locale["PHOTO_RESOLUTION"],


### PR DESCRIPTION
This PR goes with [this backend PR](https://github.com/LycheeOrg/Lychee/pull/1239) to adapt the migration of filesize from `Photo` to `SizeVariant`.