### PR TITLE
Fix location type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+npm
 node_modules/
 bower_components/
 package-lock.json

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -173,8 +173,12 @@ sidebar.createStructure.photo = function (data) {
 	if (data == null || data === "") return false;
 
 	let editable = typeof album !== "undefined" ? album.isUploadable() : false;
-	let exifHash = data.taken_at + data.make + data.model + data.shutter + data.aperture + data.focal + data.iso;
-	let locationHash = data.longitude + data.latitude + data.altitude;
+	let hasExif = !!data.taken_at || !!data.make || !!data.model || !!data.shutter || !!data.aperture || !!data.focal || !!data.iso;
+	// Attributes for geo-position are nullable floats.
+	// The geo-position 0°00'00'', 0°00'00'' at zero altitude is very unlikely
+	// but valid (it's south of the coast of Ghana in the Atlantic)
+	// So we must not calculate the sum and compare for zero.
+	let hasLocation = data.longitude !== null || data.latitude !== null || data.altitude !== null;
 	let structure = {};
 	let isPublic = "";
 	let isVideo = data.type && data.type.indexOf("video") > -1;
@@ -264,7 +268,7 @@ sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (exifHash !== "") {
+	if (hasExif !== "") {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: sidebar.types.DEFAULT,
@@ -301,7 +305,7 @@ sidebar.createStructure.photo = function (data) {
 		rows: [{ title: lychee.locale["PHOTO_LICENSE"], kind: "license", value: license, editable: editable }],
 	};
 
-	if (locationHash !== "" && locationHash !== 0) {
+	if (hasLocation) {
 		structure.location = {
 			title: lychee.locale["PHOTO_LOCATION"],
 			type: sidebar.types.DEFAULT,
@@ -325,7 +329,7 @@ sidebar.createStructure.photo = function (data) {
 				{ title: lychee.locale["PHOTO_LOCATION"], kind: "location", value: data.location ? data.location : "" },
 			],
 		};
-		if (data.img_direction) {
+		if (data.img_direction !== null) {
 			// No point in display sub-degree precision.
 			structure.location.rows.push({
 				title: lychee.locale["PHOTO_IMGDIRECTION"],

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -268,7 +268,7 @@ sidebar.createStructure.photo = function (data) {
 	};
 
 	// Only create EXIF section when EXIF data available
-	if (hasExif !== "") {
+	if (hasExif) {
 		structure.exif = {
 			title: lychee.locale["PHOTO_CAMERA"],
 			type: sidebar.types.DEFAULT,


### PR DESCRIPTION
The attributes `latitude` and `longitude` are nullable JS numbers. The latitude and longitude 0°0'0''.0000 are valid coordinates, but falsy in JS. So we must not use shortcut notations like `if (latitude)` to check if we have a latitude/longitude, but explicitly check for `!== null` .