### PR TITLE
Fix regression bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"gulp-load-plugins": "^1.5.0",
 		"gulp-sass": "^5.1.0",
 		"gulp-uglify": "^3.0.2",
-		"npm": "^6.14.16",
+		"npm": "^6.14.17",
 		"prettier": "2.2.1",
 		"sass": "^1.51.0",
 		"uglify-js": "^3.12.4"

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1147,36 +1147,30 @@ album.getArchive = function (albumIDs) {
  * @returns {string} the HTML content of the dialog
  */
 album.buildMessage = function (albumIDs, albumID, op1, op2, ops) {
-	let title = "";
-	let sTitle = "";
+	let targetTitle = lychee.locale["UNTITLED"];
+	let sourceTitle = lychee.locale["UNTITLED"];
 	let msg = "";
 
-	// Get title of first album
+	// Get title of target album
 	if (albumID === null) {
-		title = lychee.locale["ROOT"];
+		targetTitle = lychee.locale["ROOT"];
 	} else {
-		const album1 = albums.getByID(albumID);
-		if (album1) {
-			title = album1.title;
+		const targetAlbum = albums.getByID(albumID) || album.getSubByID(albumID);
+		if (targetAlbum) {
+			targetTitle = targetAlbum.title;
 		}
 	}
 
-	// Fallback for first album without a title
-	if (!title) title = lychee.locale["UNTITLED"];
-
 	if (albumIDs.length === 1) {
-		// Get title of second album
-		const album2 = albums.getByID(albumIDs[0]);
-		if (album2) {
-			sTitle = album2.title;
+		// Get title of the unique source album
+		const sourceAlbum = albums.getByID(albumIDs[0]) || album.getSubByID(albumIDs[0]);
+		if (sourceAlbum) {
+			sourceTitle = sourceAlbum.title;
 		}
 
-		// Fallback for second album without a title
-		if (!sTitle) sTitle = lychee.locale["UNTITLED"];
-
-		msg = lychee.html`<p>${lychee.locale[op1]} '$${sTitle}' ${lychee.locale[op2]} '$${title}'?</p>`;
+		msg = lychee.html`<p>${lychee.locale[op1]} '$${sourceTitle}' ${lychee.locale[op2]} '$${targetTitle}'?</p>`;
 	} else {
-		msg = lychee.html`<p>${lychee.locale[ops]} '$${title}'?</p>`;
+		msg = lychee.html`<p>${lychee.locale[ops]} '$${targetTitle}'?</p>`;
 	}
 
 	return msg;


### PR DESCRIPTION
During review of #291 I noticed that `album.buildMessage` does not work as expected, because the previous version only searches for the designated album ID in `albums.json.albums`, i.e. inside the root album. Hence, the confirmation message in #291 did not show the correct title of albums when used inside sub-albums.

I cannot remember to have changed this method during my re-factoring, but it seems so. Now it should be fixed.