### PR TITLE
Fix tag albums

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1221,8 +1221,9 @@ album.delete = function (albumIDs) {
 		msg = `<p>` + lychee.locale["DELETE_UNSORTED_CONFIRM"] + `</p>`;
 	} else if (albumIDs.length === 1) {
 		let albumTitle = "";
+		const isTagAlbum = albums.isTagAlbum(albumIDs[0]);
 
-		action.title = lychee.locale["DELETE_ALBUM_QUESTION"];
+		action.title = lychee.locale[isTagAlbum ? "DELETE_TAG_ALBUM_QUESTION" : "DELETE_ALBUM_QUESTION"];
 		cancel.title = lychee.locale["KEEP_ALBUM"];
 
 		// Get title
@@ -1239,7 +1240,9 @@ album.delete = function (albumIDs) {
 		// Fallback for album without a title
 		if (!albumTitle) albumTitle = lychee.locale["UNTITLED"];
 
-		msg = lychee.html`<p>${lychee.locale["DELETE_ALBUM_CONFIRMATION_1"]} '$${albumTitle}' ${lychee.locale["DELETE_ALBUM_CONFIRMATION_2"]}</p>`;
+		msg = lychee.html`<p>${lychee.locale[isTagAlbum ? "DELETE_TAG_ALBUM_CONFIRMATION_1" : "DELETE_ALBUM_CONFIRMATION_1"]} '$${albumTitle}' ${
+			lychee.locale[isTagAlbum ? "DELETE_TAG_ALBUM_CONFIRMATION_2" : "DELETE_ALBUM_CONFIRMATION_2"]
+		}</p>`;
 	} else {
 		action.title = lychee.locale["DELETE_ALBUMS_QUESTION"];
 		cancel.title = lychee.locale["KEEP_ALBUMS"];

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -219,3 +219,11 @@ albums.deleteByID = function (albumID) {
 albums.refresh = function () {
 	albums.json = null;
 };
+
+/**
+ * @param {?string} albumID
+ * @returns {boolean}
+ */
+albums.isTagAlbum = function (albumID) {
+	return albums.json && albums.json.tag_albums.find((tagAlbum) => tagAlbum.id === albumID);
+};

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -110,13 +110,13 @@ contextMenu.album = function (albumID, e) {
 	// Show merge-item when there's more than one album
 	// Commented out because it doesn't consider subalbums or shared albums.
 	// let showMerge = (albums.json && albums.json.albums && Object.keys(albums.json.albums).length>1);
-	const showMerge = true;
+	const showMergeMove = !albums.isTagAlbum(albumID);
 
 	const items = [
 		{ title: build.iconic("pencil") + lychee.locale["RENAME"], fn: () => album.setTitle([albumID]) },
 		{
 			title: build.iconic("collapse-left") + lychee.locale["MERGE"],
-			visible: showMerge,
+			visible: showMergeMove,
 			fn: () => {
 				basicContext.close();
 				contextMenu.move([albumID], e, album.merge, "ROOT", false);
@@ -124,7 +124,7 @@ contextMenu.album = function (albumID, e) {
 		},
 		{
 			title: build.iconic("folder") + lychee.locale["MOVE"],
-			visible: true,
+			visible: showMergeMove,
 			fn: () => {
 				basicContext.close();
 				contextMenu.move([albumID], e, album.setAlbum, "ROOT");
@@ -198,13 +198,13 @@ contextMenu.albumMulti = function (albumIDs, e) {
 	// Show merge-item when there's more than one album
 	// Commented out because it doesn't consider subalbums or shared albums.
 	// let showMerge = (albums.json && albums.json.albums && Object.keys(albums.json.albums).length>1);
-	const showMerge = true;
+	const showMergeMove = albumIDs.every((albumID) => !albums.isTagAlbum(albumID));
 
 	let items = [
 		{ title: build.iconic("pencil") + lychee.locale["RENAME_ALL"], fn: () => album.setTitle(albumIDs) },
 		{
 			title: build.iconic("collapse-left") + lychee.locale["MERGE_ALL"],
-			visible: showMerge && autoMerge,
+			visible: showMergeMove && autoMerge,
 			fn: () => {
 				let albumID = albumIDs.shift();
 				album.merge(albumIDs, albumID);
@@ -212,7 +212,7 @@ contextMenu.albumMulti = function (albumIDs, e) {
 		},
 		{
 			title: build.iconic("collapse-left") + lychee.locale["MERGE"],
-			visible: showMerge && !autoMerge,
+			visible: showMergeMove && !autoMerge,
 			fn: () => {
 				basicContext.close();
 				contextMenu.move(albumIDs, e, album.merge, "ROOT", false);
@@ -220,7 +220,7 @@ contextMenu.albumMulti = function (albumIDs, e) {
 		},
 		{
 			title: build.iconic("folder") + lychee.locale["MOVE_ALL"],
-			visible: true,
+			visible: showMergeMove,
 			fn: () => {
 				basicContext.close();
 				contextMenu.move(albumIDs, e, album.setAlbum, "ROOT");

--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -107,9 +107,6 @@ contextMenu.album = function (albumID, e) {
 
 	if (album.isSmartID(albumID) || album.isSearchID(albumID)) return;
 
-	// Show merge-item when there's more than one album
-	// Commented out because it doesn't consider subalbums or shared albums.
-	// let showMerge = (albums.json && albums.json.albums && Object.keys(albums.json.albums).length>1);
 	const showMergeMove = !albums.isTagAlbum(albumID);
 
 	const items = [
@@ -195,9 +192,6 @@ contextMenu.albumMulti = function (albumIDs, e) {
 	// Show list of albums otherwise
 	const autoMerge = albumIDs.length > 1;
 
-	// Show merge-item when there's more than one album
-	// Commented out because it doesn't consider subalbums or shared albums.
-	// let showMerge = (albums.json && albums.json.albums && Object.keys(albums.json.albums).length>1);
 	const showMergeMove = albumIDs.every((albumID) => !albums.isTagAlbum(albumID));
 
 	let items = [

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -62,7 +62,7 @@ $(document).ready(function () {
 			return true;
 		})
 		.bind(["u"], function () {
-			if (!visible.photo() && album.isUploadable()) {
+			if (!visible.photo() && album.isUploadable() && !album.isTagAlbum()) {
 				$("#upload_files").click();
 				return false;
 			}

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -68,6 +68,10 @@ lychee.locale = {
 	DELETE_ALBUM_CONFIRMATION_1: "Are you sure you want to delete the album",
 	DELETE_ALBUM_CONFIRMATION_2: "and all of the photos it contains? This action can't be undone!",
 
+	DELETE_TAG_ALBUM_QUESTION: "Delete Album",
+	DELETE_TAG_ALBUM_CONFIRMATION_1: "Are you sure you want to delete the album",
+	DELETE_TAG_ALBUM_CONFIRMATION_2: "(any photos inside will not be deleted)? This action can't be undone!",
+
 	DELETE_ALBUMS_QUESTION: "Delete Albums and Photos",
 	KEEP_ALBUMS: "Keep Albums",
 	DELETE_ALBUMS_CONFIRMATION_1: "Are you sure you want to delete all",

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -1007,7 +1007,7 @@ view.settings = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.settings.title();
 		header.setMode("config");
 		view.settings.content.init();
@@ -1631,7 +1631,7 @@ view.notifications = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.notifications.title();
 		header.setMode("config");
 		view.notifications.content.init();
@@ -1680,7 +1680,7 @@ view.users = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.users.title();
 		header.setMode("config");
 		view.users.content.init();
@@ -1765,7 +1765,7 @@ view.sharing = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.sharing.title();
 		header.setMode("config");
 		view.sharing.content.init();
@@ -1906,7 +1906,7 @@ view.logs = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.logs.title();
 		header.setMode("config");
 		view.logs.content.init();
@@ -1993,7 +1993,7 @@ view.diagnostics = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.diagnostics.title();
 		header.setMode("config");
 		view.diagnostics.content.init();
@@ -2137,7 +2137,7 @@ view.update = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.update.title();
 		header.setMode("config");
 		view.update.content.init();
@@ -2186,7 +2186,7 @@ view.u2f = {
 	init: function () {
 		multiselect.clearSelection();
 
-		view.photo.hide();
+		if (visible.photo()) view.photo.hide();
 		view.u2f.title();
 		header.setMode("config");
 		view.u2f.content.init();


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1307

Also fixes uploads via keyboard (`u`) and the confirmation string displayed for tag albums (which incorrectly informed that the contents of a tag album would be deleted).

Also includes an unrelated fix to prevent the info sidebar from being displayed in settings and such (if it was being displayed for an album and somebody then moved to the albums view and opened the settings).