### PR TITLE
Misc fixes

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -482,11 +482,11 @@ header.setMode = function (mode) {
 			}
 
 			if (album.isUploadable()) {
-				const e = $("#button_trash, #button_move, #button_visibility, #button_star");
+				const e = $("#button_trash, #button_move, #button_visibility, #button_star, #button_rotate_cwise, #button_rotate_ccwise");
 				e.show();
 				tabindex.makeFocusable(e);
 			} else {
-				const e = $("#button_trash, #button_move, #button_visibility, #button_star");
+				const e = $("#button_trash, #button_move, #button_visibility, #button_star, #button_rotate_cwise, #button_rotate_ccwise");
 				e.hide();
 				tabindex.makeUnfocusable(e);
 			}

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -42,7 +42,7 @@ photo.load = function (photoID, albumID, autoplay) {
 		// TODO: Why do we overwrite the true album ID of a photo, by the externally provided one? I guess we need it, because the album which the user came from might also be a smart album or a tag album. However, in this case I would prefer to leave the `album_id  untouched (don't rename it to `original_album_id`) and call this one `effective_album_id` instead.
 		photo.json.album_id = albumID;
 
-		if (!visible.photo()) view.photo.show();
+		view.photo.show();
 		view.photo.init(autoplay);
 		lychee.imageview.show();
 

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -521,6 +521,10 @@ photo.setAlbum = function (photoIDs, albumID) {
 photo.toggleStar = function () {
 	photo.json.is_starred = !photo.json.is_starred;
 	view.photo.star();
+
+	album.getByID(photo.json.id).is_starred = photo.json.is_starred;
+	view.album.content.star(photo.json.id);
+
 	albums.refresh();
 
 	api.post("Photo::setStar", {

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -707,31 +707,33 @@ view.photo = {
 		lychee.content.addClass("view");
 		header.setMode("photo");
 
-		// Make body not scrollable
-		// use bodyScrollLock package to enable locking on iOS
-		// Simple overflow: hidden not working on iOS Safari
-		// Only the info pane needs scrolling
-		// Touch event for swiping of photo still work
+		if (!visible.photo()) {
+			// Make body not scrollable
+			// use bodyScrollLock package to enable locking on iOS
+			// Simple overflow: hidden not working on iOS Safari
+			// Only the info pane needs scrolling
+			// Touch event for swiping of photo still work
 
-		scrollLock.disablePageScroll($(".sidebar__wrapper").get());
+			scrollLock.disablePageScroll($(".sidebar__wrapper").get());
 
-		// Fullscreen
-		let timeout = null;
-		$(document).bind("mousemove", function () {
-			clearTimeout(timeout);
-			// For live Photos: header animation only if LivePhoto is not playing
-			if (!photo.isLivePhotoPlaying() && lychee.header_auto_hide) {
-				header.show();
-				timeout = setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
+			// Fullscreen
+			let timeout = null;
+			$(document).bind("mousemove", function () {
+				clearTimeout(timeout);
+				// For live Photos: header animation only if LivePhoto is not playing
+				if (!photo.isLivePhotoPlaying() && lychee.header_auto_hide) {
+					header.show();
+					timeout = setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
+				}
+			});
+
+			// we also put this timeout to enable it by default when you directly click on a picture.
+			if (lychee.header_auto_hide) {
+				setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
 			}
-		});
 
-		// we also put this timeout to enable it by default when you directly click on a picture.
-		if (lychee.header_auto_hide) {
-			setTimeout(header.hideIfLivePhotoNotPlaying, 2500);
+			lychee.animate(lychee.imageview, "fadeIn");
 		}
-
-		lychee.animate(lychee.imageview, "fadeIn");
 	},
 
 	/**
@@ -970,8 +972,6 @@ view.photo = {
 			(photo.json.live_photo_url !== "" && photo.json.live_photo_url !== null)
 		) {
 			$("#button_rotate_cwise, #button_rotate_ccwise").hide();
-		} else {
-			$("#button_rotate_cwise, #button_rotate_ccwise").show();
 		}
 	},
 


### PR DESCRIPTION
This was supposed to be three unrelated fixes but (almost by magic) one of the fixes ended up fixing two bugs, so it's down to two fixes:
- `photo.toggleStar` wasn't updating the parent album, so toggling the star status in photo view would not be immediately reflected when going back to the parent album. This is a regression from 4.4.0,
- The rotation buttons were being shown for non-editable albums (such as public or shared albums belonging to other users, while not being an admin). This required a larger fix because we were being sloppy with hiding these buttons if the photo was actually a video file and such. Now we unconditionally call `view.photo.show` when loading a new photo (even if already in photo view, as is the case with previous/next buttons), which ensures that the header buttons are in a well-defined state. This almost accidentally fixed another obscure bug I noticed, where for albums that are not downloadable and have "original" disabled, using previous/next between a video file and an image file would end up showing the "..." menu button for the image file, even though it should be hidden in that case.