### PR TITLE
Show login dialog for user + password automatically for some cases

### DIFF
--- a/scripts/3rd-party/backend.js
+++ b/scripts/3rd-party/backend.js
@@ -134,7 +134,7 @@
  *
  * @property {string}  id
  * @property {string}  title
- * @property {Photo[]} photos
+ * @property {Photo[]} [photos]
  * @property {?Thumb}  thumb
  * @property {boolean} is_public
  * @property {boolean} is_downloadable

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -266,6 +266,21 @@ album.load = function (albumID, albumLoadedCB = null) {
 				album.load(albumID, albumLoadedCB);
 			});
 			return true;
+		} else if (lycheeException.exception.endsWith("UnauthenticatedException") && !albumLoadedCB) {
+			// If no password is required, but we still get an 401 error
+			// try to properly log in as a user
+			// We only try this, if `albumLoadedCB` is not set.
+			// This is not optimal, but the best we can do without too much
+			// refactoring for now.
+			// `albumLoadedCB` is set, if the user directly jumps to a photo
+			// in an album via a direct link.
+			// Even though the album might be private, the photo could still
+			// be visible.
+			// If we caught users for a direct link to a public photo
+			// within a private album, we would "trap" the users in a login
+			// dialog which they cannot pass by.
+			lychee.loginDialog();
+			return true;
 		} else if (albumLoadedCB) {
 			// In case we could not successfully load and unlock the album,
 			// but we have a callback, we call that and consider the error

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -267,7 +267,7 @@ album.load = function (albumID, albumLoadedCB = null) {
 			});
 			return true;
 		} else if (lycheeException.exception.endsWith("UnauthenticatedException") && !albumLoadedCB) {
-			// If no password is required, but we still get an 401 error
+			// If no password is required, but we still get a 401 error
 			// try to properly log in as a user
 			// We only try this, if `albumLoadedCB` is not set.
 			// This is not optimal, but the best we can do without too much


### PR DESCRIPTION
This PR makes the frontend show the normal user login dialog in two cases:

1. Anonymous user browse the root album and there is nothing to see without being logged in. In this case the login dialog pops up. This also applies that the login dialog re-appears after logging out.

2. Anonymous user directly jump to an album via an URL like `http://photos.my-domain.tld/#aiJnYbj6K14ULJLd0i4SmamY` and the album is _not_ password protected. If the album is password protected, then the traditional password dialog appears. In other words I gave asking for a password precedence (if one is set) above asking for a username/password. 
   This might be the "wrong" decision in cases where an album is password-protected and is shared with users at the same time, but the users do not now the shared password but would be able to login via their own credentials. In this case those users are presented with the password dialog.
   I decided to do it this way around, because the password-dialog has been there for a much longer time. If I had given the login dialog precedence, then user with an account would be better off, but anonymous user which only know the shared password would be trapped in the login dialog.
   Of course, the whole problem only exists, because we have a mix of password-protection without user authentication and user authentication. Alternatively, we would need a "combined" dialog which allows to select between logging-in via password-only or via username+password. But I did not feel like writing such a dialog.

3.  Finally, no login dialog for username+password pops up if a user directly jumps to a photo via an URL like `http://photos.my-domain.tld/#aiJnYbj6K14ULJLd0i4SmamY/9437N_8xtIcIBzSw3xOIH8un`. (However it does work for photos in password-protected albums.) The reason is that our current `lychee.loginDialog` method does not actually return, but reloads the whole page if it succeeds and then the `init` routine gets called. It would be much better to have a `login` method which logs in much more gracefully like `password.getDialog`. This could be done in theory, but again, I did not feel like rewriting the whole logic of `lychee.loginDialog`

I still think this PR is a fair improvement over the current situation.