### PR TITLE
Fix subalbum renaming via the context menu

### DIFF
--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -266,8 +266,8 @@ view.album = {
 		 * @returns {void}
 		 */
 		titleSub: function (albumID) {
-			const album = album.getSubByID(albumID);
-			const title = album.title ? album.title : lychee.locale["UNTITLED"];
+			const subalbum = album.getSubByID(albumID);
+			const title = subalbum.title ? subalbum.title : lychee.locale["UNTITLED"];
 
 			$('.album[data-id="' + albumID + '"] .overlay h1')
 				.text(title)


### PR DESCRIPTION
It is currently failing because of the use of a local variable `album` hiding the global one.