### PR TITLE
Bugfix for boolean condition in `isSearchID`

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -20,7 +20,7 @@ album.isSmartID = function (id) {
  * @returns {boolean}
  */
 album.isSearchID = function (id) {
-	return id === SearchAlbumIDPrefix || id.startsWith(SearchAlbumIDPrefix + "/");
+	return id !== null && id.startsWith(SearchAlbumIDPrefix);
 };
 
 /**

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -20,7 +20,7 @@ album.isSmartID = function (id) {
  * @returns {boolean}
  */
 album.isSearchID = function (id) {
-	return id !== null && id.startsWith(SearchAlbumIDPrefix);
+	return id !== null && (id === SearchAlbumIDPrefix || id.startsWith(SearchAlbumIDPrefix + "/"));
 };
 
 /**


### PR DESCRIPTION
Another victim of https://github.com/LycheeOrg/Lychee-front/pull/306. :grinning: I noticed that because I couldn't use "Import from Server ..." on the root level anymore and got `Uncaught TypeError: id is null` exception on the JS console.