### PR TITLE
Make album.getID more robust

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -57,9 +57,18 @@ album.getID = function () {
 	else if (album.json) id = album.json.id;
 	else if (mapview.albumID) id = mapview.albumID;
 
-	// Search
-	if (isID(id) === false) id = $(".album:hover, .album.active").attr("data-id");
-	if (isID(id) === false) id = $(".photo:hover, .photo.active").attr("data-album-id");
+	if (isID(id) === false) {
+		let active = $(".album:hover, .album.active");
+		if (active.length > 0) {
+			id = active.attr("data-id");
+		}
+	}
+	if (isID(id) === false) {
+		let active = $(".photo:hover, .photo.active");
+		if (active.length > 0) {
+			id = active.attr("data-album-id");
+		}
+	}
 
 	if (isID(id) === true) return id;
 	else return null;

--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -48,8 +48,8 @@ album.getID = function () {
 	/** @type {?string} */
 	let id = null;
 
-	// this is a Lambda
-	let isID = (_id) => {
+	/** @param {?string} _id */
+	const isID = (_id) => {
 		return album.isSmartID(_id) || album.isSearchID(_id) || album.isModelID(_id);
 	};
 
@@ -58,15 +58,15 @@ album.getID = function () {
 	else if (mapview.albumID) id = mapview.albumID;
 
 	if (isID(id) === false) {
-		let active = $(".album:hover, .album.active");
-		if (active.length > 0) {
-			id = active.attr("data-id");
+		const active = $(".album:hover, .album.active");
+		if (active.length === 1) {
+			id = active.attr("data-id") || null;
 		}
 	}
 	if (isID(id) === false) {
-		let active = $(".photo:hover, .photo.active");
-		if (active.length > 0) {
-			id = active.attr("data-album-id");
+		const active = $(".photo:hover, .photo.active");
+		if (active.length === 1) {
+			id = active.attr("data-album-id") || null;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1483

I'm honestly not sure what purpose those selectors serve at this point. There was a comment `Search` above them but that's definitely outdated now that the search results are in `album.json`. I didn't want to introduce some other embarrassing last-minute bugs by removing them so I just made them more robust instead...