### PR TITLE
Replace escaped spaces

### DIFF
--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -511,7 +511,7 @@ upload.start = {
 
 		/**
 		 * @typedef ServerImportDialogResult
-		 * @property {string} paths
+		 * @property {string|string[]} paths
 		 * @property {boolean} delete_imported
 		 * @property {boolean} import_via_symlink
 		 * @property {boolean} skip_duplicates
@@ -526,7 +526,13 @@ upload.start = {
 			} else {
 				// Consolidate `data` before we close the modal dialog
 				// TODO: We should fix the modal dialog to properly return the values of all input fields, incl. check boxes
-				data.paths = data.paths.match(/(?:\\.|\S)+/g);
+				// We split the given path string at unescaped spaces into an
+				// array or more precisely we create an array whose entries
+				// matches strings with non-space characters or escaped spaces.
+				// After splitting, the escaped spaces must be replaced by
+				// proper spaces as escaping of spaces is a GUI-only to allow
+				// input of several paths into a single input field.
+				data.paths = data.paths.match(/(?:\\ |\S)+/g).map((path) => path.replaceAll("\\ ", " "));
 				data.delete_imported = !!$(choiceDeleteSelector).prop("checked");
 				data.import_via_symlink = !!$(choiceSymlinkSelector).prop("checked");
 				data.skip_duplicates = !!$(choiceDuplicateSelector).prop("checked");

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -530,8 +530,8 @@ upload.start = {
 				// array or more precisely we create an array whose entries
 				// matches strings with non-space characters or escaped spaces.
 				// After splitting, the escaped spaces must be replaced by
-				// proper spaces as escaping of spaces is a GUI-only to allow
-				// input of several paths into a single input field.
+				// proper spaces as escaping of spaces is a GUI-only thing to
+				// allow input of several paths into a single input field.
 				data.paths = data.paths.match(/(?:\\ |\S)+/g).map((path) => path.replaceAll("\\ ", " "));
 				data.delete_imported = !!$(choiceDeleteSelector).prop("checked");
 				data.import_via_symlink = !!$(choiceSymlinkSelector).prop("checked");


### PR DESCRIPTION
This fixes a bug which is a victim of https://github.com/LycheeOrg/Lychee-front/pull/308.

Since https://github.com/LycheeOrg/Lychee-front/pull/308 a path to be imported is split at spaces into multiple paths and sent as an array of paths to backend. In order to still allow input of path which contain spaces, the space must be escaped. However, this escaping is a front-end only thing GUI-only ting to allow input of several paths into a single input field. The escaping must be reverted before the path is sent to the backend.

@ildyria Did you even test your own PR https://github.com/LycheeOrg/Lychee-front/pull/308? This cannot have ever worked.