### PR TITLE
Fix most ecaping of user provided input

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1044,7 +1044,7 @@ album.shareUsers = function (albumID) {
 						<label>
 							<input type='checkbox' name='${user.id}'>
 							<span class='checkbox'>${build.iconic("check")}</span>
-							<span class='label'>${user.username}</span>
+							<span class='label'>$${user.username}</span>
 						</label>
 						<p></p>
 					</div>`);
@@ -1199,9 +1199,9 @@ album.buildMessage = function (albumIDs, albumID, op1, ops) {
 			sourceTitle = sourceAlbum.title;
 		}
 
-		msg = lychee.html`<p>${sprintf(lychee.locale[op1], sourceTitle, targetTitle)}'</p>`;
+		msg = lychee.html`<p>${sprintf(lychee.locale[op1], lychee.escapeHTML(sourceTitle), lychee.escapeHTML(targetTitle))}'</p>`;
 	} else {
-		msg = lychee.html`<p>${sprintf(lychee.locale[ops], targetTitle)}</p>`;
+		msg = lychee.html`<p>${sprintf(lychee.locale[ops], lychee.escapeHTML(targetTitle))}</p>`;
 	}
 
 	return msg;
@@ -1271,7 +1271,10 @@ album.delete = function (albumIDs) {
 		// Fallback for album without a title
 		if (!albumTitle) albumTitle = lychee.locale["UNTITLED"];
 
-		msg = lychee.html`<p>${sprintf(lychee.locale[isTagAlbum ? "DELETE_TAG_ALBUM_CONFIRMATION" : "DELETE_ALBUM_CONFIRMATION"], albumTitle)}</p>`;
+		msg = lychee.html`<p>${sprintf(
+			lychee.locale[isTagAlbum ? "DELETE_TAG_ALBUM_CONFIRMATION" : "DELETE_ALBUM_CONFIRMATION"],
+			lychee.escapeHTML(albumTitle)
+		)}</p>`;
 	} else {
 		action.title = lychee.locale["DELETE_ALBUMS_QUESTION"];
 		cancel.title = lychee.locale["KEEP_ALBUMS"];

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -553,7 +553,7 @@ build.uploadNewFile = function (name) {
 
 /**
  * @param {string[]} tags
- * @returns {string}
+ * @returns {string} return safe HTMl code
  */
 build.tags = function (tags) {
 	let html = "";

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -21,7 +21,7 @@ build.iconic = function (icon, classes = "") {
  * @returns {string}
  */
 build.divider = function (title) {
-	return lychee.html`<div class='divider'><h1>${title}</h1></div>`;
+	return lychee.html`<div class='divider'><h1>$${title}</h1></div>`;
 };
 
 /**
@@ -92,7 +92,7 @@ build.album = function (data, disabled = false) {
 			if (formattedMinTs !== "" || formattedMaxTs !== "") {
 				// either min_taken_at or max_taken_at is set
 				subtitle = formattedMinTs === formattedMaxTs ? formattedMaxTs : formattedMinTs + " - " + formattedMaxTs;
-				subtitle = `<span title='${lychee.locale["CAMERA_DATE"]}'>${build.iconic("camera-slr")}</span>${subtitle}`;
+				subtitle = lychee.html`<span title='${lychee.locale["CAMERA_DATE"]}'>${build.iconic("camera-slr")}</span>$${subtitle}`;
 				break;
 			}
 		// fall through
@@ -133,7 +133,7 @@ build.album = function (data, disabled = false) {
 				  ${build.getAlbumThumb(data)}
 				<div class='overlay'>
 					<h1 title='$${data.title}'>$${data.title}</h1>
-					<a>${subtitle}</a>
+					<a>$${subtitle}</a>
 				</div>
 			`;
 
@@ -337,7 +337,7 @@ build.overlay_image = function (data) {
 	let overlay = "";
 	switch (build.check_overlay_type(data, lychee.image_overlay_type)) {
 		case "desc":
-			overlay = data.description;
+			overlay = lychee.escapeHTML(data.description);
 			break;
 		case "date":
 			if (data.taken_at != null)
@@ -517,7 +517,7 @@ build.uploadModal = function (title, files) {
 
 		html += lychee.html`
 				<div class='row'>
-					<a class='name'>${file.name}</a>
+					<a class='name'>$${file.name}</a>
 					<a class='status'></a>
 					<p class='notice'></p>
 				</div>
@@ -544,7 +544,7 @@ build.uploadNewFile = function (name) {
 
 	return lychee.html`
 		<div class='row'>
-			<a class='name'>${name}</a>
+			<a class='name'>$${name}</a>
 			<a class='status'></a>
 			<p class='notice'></p>
 		</div>

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -345,7 +345,7 @@ photo.delete = function (photoIDs) {
 		action.title = lychee.locale["PHOTO_DELETE"];
 		cancel.title = lychee.locale["PHOTO_KEEP"];
 
-		msg = lychee.html`<p>${sprintf(lychee.locale["PHOTO_DELETE_CONFIRMATION"], photoTitle)}</p>`;
+		msg = lychee.html`<p>${sprintf(lychee.locale["PHOTO_DELETE_CONFIRMATION"], lychee.escapeHTML(photoTitle))}</p>`;
 	} else {
 		action.title = lychee.locale["PHOTO_DELETE"];
 		cancel.title = lychee.locale["PHOTO_KEEP"];

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -546,9 +546,9 @@ sidebar.render = function (structure) {
 	 * @returns {string}
 	 */
 	const renderDefault = function (section) {
-		let _html = `
+		let _html = lychee.html`
 				 <div class='sidebar__divider'>
-					 <h1>${section.title}</h1>
+					 <h1>$${section.title}</h1>
 				 </div>
 				 <table>
 				 `;
@@ -599,8 +599,8 @@ sidebar.render = function (structure) {
 
 				_html += lychee.html`
 						 <tr>
-							 <td>${row.title}</td>
-							 <td>${value}</td>
+							 <td>$${row.title}</td>
+							 <td>$${value}</td>
 						 </tr>
 						 `;
 			}
@@ -627,11 +627,11 @@ sidebar.render = function (structure) {
 
 		_html += lychee.html`
 				 <div class='sidebar__divider'>
-					 <h1>${section.title}</h1>
+					 <h1>$${section.title}</h1>
 				 </div>
 				 <div id='tags'>
-					 <div class='attr_${section.title.toLowerCase()}'>${section.value}</div>
-					 ${editable}
+					 <div class='attr_${section.title.toLowerCase()}'>$${section.value}</div>
+					 $${editable}
 				 </div>
 				 `;
 

--- a/scripts/main/sidebar.js
+++ b/scripts/main/sidebar.js
@@ -570,45 +570,42 @@ sidebar.render = function (structure) {
 		}
 
 		section.rows.forEach(function (row) {
-			let value = row.value;
+			const rawValue = row.value;
 
-			// show only rows which have a value or are editable
-			if (!(value === "" || value == null) || row.editable === true) {
-				// Wrap span-element around value for easier selecting on change
-				if (Array.isArray(row.value)) {
-					value = row.value.reduce(
-						/**
-						 * @param {string} prev
-						 * @param {string} cur
-						 */
-						function (prev, cur) {
-							// Add separator if needed
-							if (prev !== "") {
-								prev += lychee.html`<span class='attr_${row.kind}_separator'>, </span>`;
-							}
-							return prev + lychee.html`<span class='attr_${row.kind} search'>$${cur}</span>`;
-						},
-						""
-					);
-				} else {
-					value = lychee.html`<span class='attr_${row.kind}'>$${value}</span>`;
-				}
-
-				// Add edit-icon to the value when editable
-				if (row.editable === true) value += " " + build.editIcon("edit_" + row.kind);
-
-				_html += lychee.html`
-						 <tr>
-							 <td>$${row.title}</td>
-							 <td>$${value}</td>
-						 </tr>
-						 `;
+			// don't show rows which are empty and cannot be edited
+			if ((rawValue === "" || rawValue == null) && row.editable === false) {
+				return;
 			}
+
+			/** @type {string} */
+			let htmlValue;
+			// Wrap span-element around value for easier selecting on change
+			if (Array.isArray(rawValue)) {
+				htmlValue = rawValue.reduce(
+					/**
+					 * @param {string} prev
+					 * @param {string} cur
+					 */
+					function (prev, cur) {
+						// Add separator if needed
+						if (prev !== "") {
+							prev += lychee.html`<span class='attr_${row.kind}_separator'>, </span>`;
+						}
+						return prev + lychee.html`<span class='attr_${row.kind} search'>$${cur}</span>`;
+					},
+					""
+				);
+			} else {
+				htmlValue = lychee.html`<span class='attr_${row.kind}'>$${rawValue}</span>`;
+			}
+
+			// Add edit-icon to the value when editable
+			if (row.editable === true) htmlValue += " " + build.editIcon("edit_" + row.kind);
+
+			_html += lychee.html`<tr><td>$${row.title}</td><td>${htmlValue}</td></tr>`;
 		});
 
-		_html += `
-				 </table>
-				 `;
+		_html += "</table>";
 
 		return _html;
 	};
@@ -618,24 +615,22 @@ sidebar.render = function (structure) {
 	 * @returns {string}
 	 */
 	const renderTags = function (section) {
-		let _html = "";
-		let editable = "";
-
 		// TODO: IDE warns me that the `Section` has no properties `editable` nor `value`; cause of the problem is that the section `tags` is built differently, see above
 		// Add edit-icon to the value when editable
-		if (section.editable === true) editable = build.editIcon("edit_tags");
+		const htmlEditable = section.editable === true ? build.editIcon("edit_tags") : "";
 
-		_html += lychee.html`
+		// Note: In case of tags `section.value` already contains proper
+		// HTML (with each tag wrapped into a `<span>`-element), because
+		// `section.value` is the result of `build.renderTags`.
+		return lychee.html`
 				 <div class='sidebar__divider'>
 					 <h1>$${section.title}</h1>
 				 </div>
 				 <div id='tags'>
-					 <div class='attr_${section.title.toLowerCase()}'>$${section.value}</div>
-					 $${editable}
+					 <div class='attr_${section.title.toLowerCase()}'>${section.value}</div>
+					 ${htmlEditable}
 				 </div>
 				 `;
-
-		return _html;
 	};
 
 	let html = "";

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -1796,20 +1796,20 @@ view.sharing = {
 			}
 
 			const albumOptions = sharing.json.albums.reduce(function (acc, _album) {
-				return acc + `<option value="${_album.id}">${_album.title}</option>`;
+				return acc + lychee.html`<option value="${_album.id}">$${_album.title}</option>`;
 			}, "");
 
 			const userOptions = sharing.json.users.reduce(function (acc, _user) {
-				return acc + `<option value="${_user.id}">${_user.username}</option>`;
+				return acc + lychee.html`<option value="${_user.id}">$${_user.username}</option>`;
 			}, "");
 
 			const sharingOptions = sharing.json.shared.reduce(function (acc, _shareInfo) {
 				return (
 					acc +
-					`
+					lychee.html`
 						<p>
-							<span class="text">${_shareInfo.title}</span>
-							<span class="text">${_shareInfo.username}</span>
+							<span class="text">$${_shareInfo.title}</span>
+							<span class="text">$${_shareInfo.username}</span>
 							<span class="choice">
 								<label>
 									<input type="checkbox" name="remove_id" value="${_shareInfo.id}"/>


### PR DESCRIPTION
This PR add `lychee.html` and the double-dollar operator in front of user-supplied data.

I did a quick search for the regex `[^$]\$\{[^}]*(title|Title|name|desc)` and hopefully I found all problematic cases. This is a hotfix. In particular it might introduce some undesired regression due to "double" escaping. But it should mostly be fine.