### PR TITLE
Limit HTML escaping to album description

### DIFF
--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -86,7 +86,7 @@ build.album = function (data, disabled = false) {
 	// default: any other type defaults to old style setting subtitles based of album sorting
 	switch (lychee.album_subtitle_type) {
 		case "description":
-			subtitle = data.description ? data.description : "";
+			subtitle = data.description ? lychee.escapeHTML(data.description) : "";
 			break;
 		case "takedate":
 			if (formattedMinTs !== "" || formattedMaxTs !== "") {
@@ -133,7 +133,7 @@ build.album = function (data, disabled = false) {
 				  ${build.getAlbumThumb(data)}
 				<div class='overlay'>
 					<h1 title='$${data.title}'>$${data.title}</h1>
-					<a>$${subtitle}</a>
+					<a>${subtitle}</a>
 				</div>
 			`;
 


### PR DESCRIPTION
This fixes a regression introduced in #325, where the whole subtitle is escaped, not just the case when it's a user-supplied `description`. In particular, if the `album_subtitle_style` config is set to `takedate`, the subtitle is a `<span>`, which on current master results in eyesores like this:

![2-crop](https://user-images.githubusercontent.com/16415200/192690572-95d21be3-144b-4cbd-99f0-d7c73b9c310b.jpg)

In my opinion the issue being fixed is a release-blocker so this PR should be merged before 4.6.1 is released.