### PR TITLE
Fix dependency of package basicModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.0.10",
 			"license": "MIT",
 			"dependencies": {
-				"basicmodal": "LycheeOrg/basicModal#30e6b70",
+				"basicmodal": "LycheeOrg/basicModal#v4.0.1",
 				"jquery": "^3.4.0",
 				"justified-layout": "^4.1.0",
 				"lazysizes": "^5.3.0",
@@ -100,9 +100,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
-			"integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
+			"version": "18.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
+			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
 			"dev": true
 		},
 		"node_modules/aggregate-error": {
@@ -1392,8 +1392,8 @@
 		},
 		"node_modules/basicmodal": {
 			"name": "@lychee-org/basicmodal",
-			"version": "4.0.0",
-			"resolved": "git+ssh://git@github.com/LycheeOrg/basicModal.git#30e6b70f957b23354b5674e6cdaea46128f675ed",
+			"version": "4.0.1",
+			"resolved": "git+ssh://git@github.com/LycheeOrg/basicModal.git#44bbca9b4fd040ab6505c1f3b75abf423e6a153c",
 			"license": "MIT"
 		},
 		"node_modules/binary-extensions": {
@@ -1520,9 +1520,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001421",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001421.tgz",
-			"integrity": "sha512-Sw4eLbgUJAEhjLs1Fa+mk45sidp1wRn5y6GtDpHGBaNJ9OCDJaVh2tIaWWUnGfuXfKf1JCBaIarak3FkVAvEeA==",
+			"version": "1.0.30001422",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+			"integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
 			"dev": true,
 			"funding": [
 				{
@@ -3644,9 +3644,9 @@
 			"dev": true
 		},
 		"node_modules/is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -9759,9 +9759,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.11.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
-			"integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
+			"version": "18.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
+			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
 			"dev": true
 		},
 		"aggregate-error": {
@@ -10878,8 +10878,8 @@
 			}
 		},
 		"basicmodal": {
-			"version": "git+ssh://git@github.com/LycheeOrg/basicModal.git#30e6b70f957b23354b5674e6cdaea46128f675ed",
-			"from": "basicmodal@LycheeOrg/basicModal#30e6b70"
+			"version": "git+ssh://git@github.com/LycheeOrg/basicModal.git#44bbca9b4fd040ab6505c1f3b75abf423e6a153c",
+			"from": "basicmodal@LycheeOrg/basicModal#v4.0.1"
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -10981,9 +10981,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001421",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001421.tgz",
-			"integrity": "sha512-Sw4eLbgUJAEhjLs1Fa+mk45sidp1wRn5y6GtDpHGBaNJ9OCDJaVh2tIaWWUnGfuXfKf1JCBaIarak3FkVAvEeA==",
+			"version": "1.0.30001422",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+			"integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
 			"dev": true
 		},
 		"chalk": {
@@ -12737,9 +12737,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"node": ">= 10"
 	},
 	"dependencies": {
-		"basicmodal": "LycheeOrg/basicModal#30e6b70",
+		"basicmodal": "LycheeOrg/basicModal#v4.0.1",
 		"jquery": "^3.4.0",
 		"justified-layout": "^4.1.0",
 		"lazysizes": "^5.3.0",


### PR DESCRIPTION
When I merged https://github.com/LycheeOrg/Lychee-front/pull/322 I once again forgot to revert the dependency for `basicModal` from a GIT commit hash to a proper version number. :cursing_face:

Optimally, we would have an automatic check which forbids to merge PRs which don't have proper version numbers in their dependency file. I don't know how many times I will do this silly mistake over and over again.