### PR TITLE
Improve performance of time localization

### DIFF
--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -509,7 +509,7 @@ lychee.locale = {
 	UPDATE: "Update",
 	SETTINGS_DROPBOX_KEY: "Dropbox-API-Schlüssel",
 
-	dateTimeFormatter: new Intl.DateTimeFormat('default', { dateStyle: "medium", timeStyle: "medium" }),
+	dateTimeFormatter: new Intl.DateTimeFormat("default", { dateStyle: "medium", timeStyle: "medium" }),
 
 	/**
 	 * Formats a number representing a filesize in bytes as a localized string

--- a/scripts/main/lychee_locale.js
+++ b/scripts/main/lychee_locale.js
@@ -509,6 +509,8 @@ lychee.locale = {
 	UPDATE: "Update",
 	SETTINGS_DROPBOX_KEY: "Dropbox-API-Schlüssel",
 
+	dateTimeFormatter: new Intl.DateTimeFormat('default', { dateStyle: "medium", timeStyle: "medium" }),
+
 	/**
 	 * Formats a number representing a filesize in bytes as a localized string
 	 * @param {!number} filesize
@@ -582,9 +584,7 @@ lychee.locale = {
 		//  - 3: the timezone separator, i.e. "Z", "-" or "+" (if present)
 		//  - 4: the absolute timezone offset without the sign (if present)
 		console.assert(splitDateTime.length === 5, "'jsonDateTime' is not formatted acc. to ISO 8601; passed string was: " + jsonDateTime);
-		const locale = "default"; // use the user's browser settings
-		const format = { dateStyle: "medium", timeStyle: "medium" };
-		let result = new Date(splitDateTime[1]).toLocaleString(locale, format);
+		let result = lychee.locale.dateTimeFormatter.format(new Date(splitDateTime[1]));
 		if (splitDateTime[3] === "Z" || splitDateTime[4] === "00:00") {
 			result += " UTC";
 		} else {


### PR DESCRIPTION
While I have been working on some other PRs I noticed that for 5% of the runtime for layouting large albums listings was spent for localization of the date/time.

For each album/photo the JS engine built a `DateTimeFormat` object internally when `Date::toLocaleString` was called. This PR swaps it. The `DateTimeFormat` object is only built once globally, and then we use `DateTimeFormat::format(date)` to localize the date.