### PR TITLE
Compatible with < ES2021

### DIFF
--- a/scripts/csrf_protection.js
+++ b/scripts/csrf_protection.js
@@ -21,5 +21,5 @@ csrf.getCSRFCookieValue = function () {
 	// When we send back the value to the server as part of an AJAX request,
 	// Laravel expects an unpadded value.
 	// Hence, we must remove the `%3D`.
-	return cookie ? cookie.split("=")[1].trim().replaceAll("%3D", "") : null;
+	return cookie ? cookie.split("=")[1].trim().replace(/%3D/g, "") : null;
 };

--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -942,7 +942,7 @@ upload.start = {
 			// After splitting, the escaped spaces must be replaced by
 			// proper spaces as escaping of spaces is a GUI-only thing to
 			// allow input of several paths into a single input field.
-			data.paths = data.paths.match(/(?:\\ |\S)+/g).map((path) => path.replaceAll("\\ ", " "));
+			data.paths = data.paths.match(/(?:\\ |\S)+/g).map((path) => path.replace(/\\ /g, " "));
 			basicModal.close(false, () => importFromServer(data));
 		};
 


### PR DESCRIPTION
`replaceAll` was lately introduced with ES2021. `6.72%` of the population does not seems to be compatible with it https://caniuse.com/mdn-javascript_builtins_string_replaceall
This (very simple) PR goal is to allow viewing and browsing albums on older devices/browsers not supporting ES2021 (update [scripts/csrf_protection.js](https://github.com/LycheeOrg/Lychee-front/compare/master...pchampio:Lychee-front:patch-1#diff-620863fd7b0f5cf1cc1bf523a3cba85142f9339b28faaf1c0cf74968aac085b5)).

`replaceAll`  is **replaced** with the older replace function with regex.

For good measure, I've also updated [scripts/main/upload.js](https://github.com/LycheeOrg/Lychee-front/compare/master...pchampio:Lychee-front:patch-1#diff-fc7e54aab2fa327b01b451db95a3be861edf80101e3eca5ddd85fea21ced36fa) even through I have not extensively tested the upload on the older device.

```js
"\\ ".replace(/\\ /g, " ") == "\\ ".replaceAll("\\ ", " ") && "\\".replaceAll("\\ ", " ") == "\\".replace(/\\ /g, " ")
=> true
```