### PR TITLE
Fixes #347

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1521,8 +1521,19 @@ album.apply_nsfw_filter = function () {
 /**
  * Determines whether the user can upload to the currently active album.
  *
- * For special cases of no album / smart album / etc. we return true.
- * It's only for regular, non-matching albums that we return false.
+ * It is safe to call this method even if no album is loaded at all.
+ * In this case, the method simply returns `false` (even for admin users).
+ *
+ * If no user is authenticated or the authenticated user has no upload
+ * capabilities, the method returns `false` (even for albums owned by the
+ * user).
+ * For admin users the method returns `true`.
+ *
+ * For non-admin, authenticated users with the upload capability
+ *
+ *  - the method returns `true` for smart albums
+ *  - the method returns `true` for regular albums if and only if the album is
+ *    owned by the currently authenticated user.
  *
  * @returns {boolean}
  */
@@ -1550,7 +1561,7 @@ album.isUploadable = function () {
 	if (lychee.rights.is_admin) {
 		return true;
 	}
-	if (lychee.publicMode || !lychee.rights.may_upload) {
+	if (lychee.user === null || lychee.publicMode || !lychee.rights.may_upload) {
 		return false;
 	}
 
@@ -1561,7 +1572,7 @@ album.isUploadable = function () {
 	}
 
 	// TODO: Comparison of numeric user IDs (instead of names) should be more robust
-	return lychee.user !== null && album.json.owner_name === lychee.user.username;
+	return album.json.owner_name === lychee.user.username;
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee-front/issues/347. The regression was introduced by https://github.com/LycheeOrg/Lychee/pull/1443.

Before https://github.com/LycheeOrg/Lychee/pull/1443 the method `album.isUploadable` relied on the undefinedness of the attribute `album.owner_name` as an implicit indicator wether the album at hand was a smart album. While this is still true, i.e. smart album still don't have an owner, this bug fix adds an explicit check for smart albums instead of implicitly relying on the fact that the previous boolean condition "accidentally" evaluated to `true` for undefined values.
