### PR TITLE
Fix various GUI issues

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1535,9 +1535,24 @@ album.apply_nsfw_filter = function () {
  *  - the method returns `true` for regular albums if and only if the album is
  *    owned by the currently authenticated user.
  *
+ * Note, for the time being this method contains a work-around in case
+ * no album is loaded, but the root view is visible.
+ * Currently, this is necessary, because this method is (erroneously) called
+ * for the root view as well.
+ * In order to determine whether the work-around for the root view needs to
+ * be applied, this method checks if the root view is visible based on the
+ * visibility of the corresponding headers.
+ * Hence, the caller must ensure that the appropriate header is set first
+ * in order to obtain a correct result from this method.
+ *
  * @returns {boolean}
  */
 album.isUploadable = function () {
+	// Work-around in case this method is called for the root view
+	if (visible.albums()) {
+		return lychee.rights.is_admin || (lychee.user !== null && !lychee.publicMode && lychee.rights.may_upload);
+	}
+
 	// If no album is loaded, nobody (not even the admin) can upload photos.
 	// We must check this first, before we test for the admin short-cut.
 	//

--- a/scripts/main/albums.js
+++ b/scripts/main/albums.js
@@ -12,6 +12,26 @@ const albums = {
  */
 albums.load = function () {
 	const showRootAlbum = function () {
+		// DO NOT change the order of `header.setMode` and `view.albums.init`.
+		// The latter relies on the header being set correctly.
+		//
+		// `view.albums.init` builds the HTML of the albums view (note the
+		// plural-s).
+		// Internally, this exploits code for regular albums which in
+		// turn calls `album.isUploadabe` (note the missing plural-s) to
+		// check whether the current album supports drag-&-drop.
+		// In order to return the correct value `album.isUploadabe` resorts
+		// to a hack: if no (regular) album is loaded `album.isUploadabe`
+		// normally returns `false` except the root album is visible.
+		// In that case `album.isUploadabe` returns a "fake" `true`.
+		// However, in order to do so `album.isUploadabe` needs to check
+		// whether the root album is visible which is determined by the
+		// visibility of the corresponding header.
+		// That is why the header needs to be set first.
+		//
+		// However, the actual bug is to call `album.isUploadable` for the
+		// root view.
+		// TODO: Fix the bug described above.
 		header.setMode("albums");
 		view.albums.init();
 		lychee.animate(lychee.content, "contentZoomIn");

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -76,6 +76,37 @@ build.album = function (data, disabled = false) {
 	const formattedCreationTs = lychee.locale.printMonthYear(data.created_at);
 	const formattedMinTs = lychee.locale.printMonthYear(data.min_taken_at);
 	const formattedMaxTs = lychee.locale.printMonthYear(data.max_taken_at);
+	// The condition below is faulty wrt. to two issues:
+	//
+	//  a) The condition only checks whether the owning/current album is
+	//     uploadable (aka "editable"), but it does not check whether the
+	//     album at hand whose icon is built is editable.
+	//     But this is of similar importance.
+	//     Currently, we only check whether the album at hand is a smart
+	//     album or tag album which are always considered non-editable.
+	//     But this is only half of the story.
+	//     For example, a regular album might still be non-editable, if the
+	//     current user is not the owner of that album.
+	//  b) This method is not only called if the owning/current album is a
+	//     proper album, but also for the root view.
+	//     However, `album.isUploadable` should not be called for the root
+	//     view.
+	//
+	// Moreover, we have to distinguish between "drag" and "drop".
+	// Doing so would also solve the problems above:
+	//
+	// - "Drag": If the current child album at hand can be dragged (away)
+	//   is mostly determined by the user's rights on the parent album.
+	//   Instead of (erroneously) using `album.isUploadable()` for that
+	//   (even for the root view), the "right to drag" should be passed to
+	//   this method as a parameter very much like `disabled` such that this
+	//   method can be used for both regular albums and the root view.
+	// - "Drop": If something (e.g. a photo) can be dropped onto the child
+	//   album at hand is independent of the user's rights on the containing
+	//   album.
+	//   Whether the child album supports the drop event depends on the type
+	//   of the album (i.e. it must not be a smart or tag album), but also
+	//   on the ownership of the album.
 	const disableDragDrop = !album.isUploadable() || disabled || album.isSmartID(data.id) || data.is_tag_album;
 	let subtitle = formattedCreationTs;
 

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -330,7 +330,15 @@ header.setMode = function (mode) {
 				tabindex.makeFocusable(e);
 			}
 
-			if (album.json && album.json.hasOwnProperty("is_share_button_visible") && !album.json.is_share_button_visible) {
+			if (
+				album.json &&
+				album.json.is_share_button_visible === false &&
+				// The owner of an album (or the admin) shall always see
+				// the share button and be unaffected by the settings of
+				// the album
+				(lychee.user === null || lychee.user.username !== album.json.owner_name) &&
+				!lychee.rights.is_admin
+			) {
 				const e = $("#button_share_album");
 				e.hide();
 				tabindex.makeUnfocusable(e);

--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -315,6 +315,24 @@ $(document).ready(function () {
 			},
 			false
 		)
+		// In the long run, the "drop" event should not be defined on the
+		// global document element, but on the `DIV` which corresponds to the
+		// view onto which something is dropped.
+		// This would also avoid this highly fragile condition below.
+		// For example, in order to avoid that a photo unintentionally ends
+		// up in the root album when someone drops a photo while the
+		// setting screen is opened, we check for `!visible.config()`.
+		// This would simply not be necessary, if the drop event was directly
+		// defined on the albums view where it belongs.
+		// The conditions whether a user is allowed to upload to the root
+		// album (cp. `visible.albums()` below) or to a regular album
+		// (cp. `visible.album()` below) are slightly different.
+		// Nonetheless, we only have a single method `album.isUploadable`
+		// which tries to cover both cases and is prone to fail in certain
+		// corner cases.
+		// If the drop event was defined on the DIV for the root view and on
+		// the DIV for an album view, the whole problem would not exist.
+		// TODO: Fix that
 		.on(
 			"drop",
 			/** @param {jQuery.Event} e */ function (e) {

--- a/scripts/main/photo.js
+++ b/scripts/main/photo.js
@@ -671,7 +671,7 @@ photo.setProtectionPolicy = function (photoID) {
 				// users?
 				formElements.requires_link.checked = false;
 				formElements.is_downloadable.checked = album.json.is_downloadable;
-				formElements.is_share_button_visible = album.json.is_share_button_visible;
+				formElements.is_share_button_visible.checked = album.json.is_share_button_visible;
 				formElements.has_password.checked = album.json.has_password;
 			}
 			basicModal.hideActionButton();
@@ -685,7 +685,7 @@ photo.setProtectionPolicy = function (photoID) {
 			formElements.grants_full_photo.checked = lychee.full_photo;
 			formElements.requires_link.checked = lychee.public_photos_hidden;
 			formElements.is_downloadable.checked = lychee.downloadable;
-			formElements.is_share_button_visible = lychee.share_button_visible;
+			formElements.is_share_button_visible.checked = lychee.share_button_visible;
 			formElements.has_password.checked = false;
 		}
 	};


### PR DESCRIPTION
This PR fixes various GUI which @kamil4 discovered during his tests of https://github.com/LycheeOrg/Lychee-front/pull/323 (see https://github.com/LycheeOrg/Lychee-front/pull/323#issuecomment-1304713804), but which already affect the current master. I hope I fixed all of them without breaking anything else. :see_no_evil:

I also hijacked @ildyria PR https://github.com/LycheeOrg/Lychee/pull/1578 for the backend to sync these fixes. Hence, you can simply checkout https://github.com/LycheeOrg/Lychee/pull/1578 to test the changes.

@kamil4 wrote in https://github.com/LycheeOrg/Lychee-front/pull/323#issuecomment-1304713804

> Uploading to the root album (albums view) doesn't work for an admin for me (weirdly, it seems to pass an ID of one of the tag albums in the Photo:add request?!). Unusually, it works for non-admin users.

Should be fixed by https://github.com/LycheeOrg/Lychee-front/commit/aaa6f380289cc7502d5398ecdd4e1825daf6c804. While the fix itself seems to be easy, I added _a lot_ of comments to warn about the fragility of the code.

> Album owners don't get to see the "Share" button in the header until the album is made public and the "Share button is visible" is checked.

Should be fixed by https://github.com/LycheeOrg/Lychee-front/commit/1286b08b4fbb551ac4e3eb26c8cda6da1bf22132. This bug seems to be around for a very long time now. I don't have any non-admin users for my gallery and even if I had I assume I would not have noticed that bug.

> When the album is made public and the "Share button is visible" is checked, going (as an authenticated owner) to one of the photos inside the album and opening the visibility dialog is supposed to display read-only visibility status, in this case including a checked "Share button is visible". But that button is not checked.

Should be fixed by https://github.com/LycheeOrg/Lychee-front/commit/0e023592409f160974a44fff69b552a61fc41990. This one was a silly oversight when migrating to the new modal dialog.
