### PR TITLE
Repairs QR code

### DIFF
--- a/scripts/main/album.js
+++ b/scripts/main/album.js
@@ -1256,11 +1256,22 @@ album.qrCode = function () {
 		return;
 	}
 
-	basicModal.show({
-		body: "<div class='qr-code-canvas'></div>",
-		classList: ["qr-code"],
-		readyCB: function (formElements, dialog) {
-			const qrcode = dialog.querySelector("div.qr-code-canvas");
+	// We need this indirection based on a resize observer, because the ready
+	// callback of the dialog is invoked _before_ the dialog is made visible
+	// in order to allow the ready callback to make initializations of
+	// form elements without causing flicker.
+	// However, for invisible elements `.clientWidth` returns zero, hence
+	// we cannot paint the QR code onto the canvas before it becomes visible.
+	const qrCodeCanvasObserver = (function () {
+		let width = 0;
+		return new ResizeObserver(function (entries, observer) {
+			const qrCodeCanvas = entries[0].target;
+			// Avoid infinite resize events due to clearing and repainting
+			// the same QR code on the canvas.
+			if (width === qrCodeCanvas.clientWidth) {
+				return;
+			}
+			width = qrCodeCanvas.clientWidth;
 			QrCreator.render(
 				{
 					text: location.href,
@@ -1268,10 +1279,19 @@ album.qrCode = function () {
 					ecLevel: "H",
 					fill: "#000000",
 					background: "#FFFFFF",
-					size: qrcode.clientWidth,
+					size: width,
 				},
-				qrcode
+				qrCodeCanvas
 			);
+		});
+	})();
+
+	basicModal.show({
+		body: "<canvas></canvas>",
+		classList: ["qr-code"],
+		readyCB: function (formElements, dialog) {
+			const qrCodeCanvas = dialog.querySelector("canvas");
+			qrCodeCanvasObserver.observe(qrCodeCanvas);
 		},
 		buttons: {
 			cancel: {


### PR DESCRIPTION
This fixes the broken QR code as noticed by @kamil4.

I assume the comment in the code explains the problem pretty straight forward

```php
// We need this indirection based on a resize observer, because the ready
// callback of the dialog is invoked _before_ the dialog is made visible
// in order to allow the ready callback to make initializations of
// form elements without causing flicker.
// However, for invisible elements `.clientWidth` returns zero, hence
// we cannot paint the QR code onto the canvas before it becomes visible.
```

Of course, an easier fix would have been to simply hard-code the width of the canvas into the JS code. However, this would have required to keep it in sync with style sheet which momentarily makes the canvas to be 300px (width of dialog) - 2 x 12px (padding of dialog) = 276px wide. I decided to implement a little bit more complicated, but hopefully more robust solution.