### PR TITLE
Configurable display of the number of subalbums

### DIFF
--- a/scripts/3rd-party/backend.js
+++ b/scripts/3rd-party/backend.js
@@ -98,7 +98,7 @@
  * @property {boolean} grants_full_photo
  * @property {boolean} requires_link
  * @property {boolean} has_password
- * @property {boolean} has_albums
+ * @property {string} num_albums
  * @property {?string} min_taken_at
  * @property {?string} max_taken_at
  * @property {?SortingCriterion} sorting

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -191,7 +191,7 @@ build.album = function (data, disabled = false) {
 		html += lychee.html`
 				<div class='subalbum_badge'>
 				<a class='badge badge--folder'>${build.iconic("folder")}`;
-		if (data.num_albums > 1) html += lychee.html`<span>${data.num_albums}</span>`;
+		if (lychee.show_num_albums && data.num_albums > 1) html += lychee.html`<span>${data.num_albums}</span>`;
 		html += lychee.html`</a>
 				</div>`;
 	}

--- a/scripts/main/build.js
+++ b/scripts/main/build.js
@@ -187,10 +187,12 @@ build.album = function (data, disabled = false) {
 				`;
 	}
 
-	if ((data.albums && data.albums.length > 0) || data.has_albums) {
+	if ((data.albums && data.albums.length > 0) || data.num_albums > 0) {
 		html += lychee.html`
 				<div class='subalbum_badge'>
-					<a class='badge badge--folder'>${build.iconic("layers")}</a>
+				<a class='badge badge--folder'>${build.iconic("folder")}`;
+		if (data.num_albums > 1) html += lychee.html`<span>${data.num_albums}</span>`;
+		html += lychee.html`</a>
 				</div>`;
 	}
 

--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -147,6 +147,7 @@ const lychee = {
 	nsfw_banner_override: "",
 
 	album_subtitle_type: "oldstyle",
+	show_num_albums: false,
 
 	upload_processing_limit: 4,
 
@@ -574,6 +575,7 @@ lychee.parsePublicInitializationData = function (data) {
 	lychee.sorting_photos = data.config.sorting_photos;
 	lychee.sorting_albums = data.config.sorting_albums;
 	lychee.album_subtitle_type = data.config.album_subtitle_type || "oldstyle";
+	lychee.show_num_albums = data.config.show_num_albums === "1";
 	lychee.checkForUpdates = data.config.check_for_updates;
 	lychee.layout = Number.parseInt(data.config.layout, 10);
 	if (Number.isNaN(lychee.layout)) lychee.layout = 1;

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -253,8 +253,16 @@
 		background: none;
 		border: none;
 		.iconic {
-			width: 12px;
-			height: 12px;
+			filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.6));
+		}
+		span {
+			position: absolute;
+			right: 11px;
+			bottom: 8px;
+			color: #222;
+			font-weight: bold;
+			font-size: 8pt;
+			text-shadow: none;
 		}
 	}
 }
@@ -318,8 +326,12 @@
 			}
 			&--folder {
 				.iconic {
-					width: 8px;
-					height: 8px;
+					filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.6));
+				}
+				span {
+					right: 7px;
+					bottom: 4px;
+					font-size: 6pt;
 				}
 			}
 		}
@@ -369,9 +381,10 @@
 				height: 14px;
 			}
 			&--folder {
-				.iconic {
-					width: 9px;
-					height: 9px;
+				span {
+					right: 8px;
+					bottom: 5px;
+					font-size: 7pt;
 				}
 			}
 		}
@@ -420,9 +433,9 @@
 				height: 16px;
 			}
 			&--folder {
-				.iconic {
-					width: 10px;
-					height: 10px;
+				span {
+					right: 9px;
+					bottom: 6px;
 				}
 			}
 		}

--- a/styles/main/_content.scss
+++ b/styles/main/_content.scss
@@ -329,9 +329,9 @@
 					filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.6));
 				}
 				span {
-					right: 7px;
-					bottom: 4px;
-					font-size: 6pt;
+					right: 4px;
+					bottom: 5px;
+					font-size: 5pt;
 				}
 			}
 		}
@@ -382,9 +382,9 @@
 			}
 			&--folder {
 				span {
-					right: 8px;
+					right: 5px;
 					bottom: 5px;
-					font-size: 7pt;
+					font-size: 6pt;
 				}
 			}
 		}
@@ -434,8 +434,9 @@
 			}
 			&--folder {
 				span {
-					right: 9px;
-					bottom: 6px;
+					right: 6px;
+					bottom: 7px;
+					font-size: 7pt;
 				}
 			}
 		}


### PR DESCRIPTION
This pull request adds a configurable option 'show_num_albums' to display the number of subalbums on the subalbum icon. The marker for albums with subalbums was based on the svg symbol 'layers'. This has been changed to the symbol 'folder', which seems to more appropriate and provides a better background for displaying the number of subalbums. In addition, a light shadow has been added to the folder symbol for better visibility on light backgrounds. As a consequence the variable 'has_albums' is no longer needed and is retired in favour of 'num_albums'. 

In order to efficiently determine the number of subalbums (based on _lft and _rgt values) and to make this option configurable changes to the Lychee backend are required.
