### PR TITLE
wrap long menu entries

### DIFF
--- a/scripts/main/contextMenu.js
+++ b/scripts/main/contextMenu.js
@@ -5,6 +5,10 @@
 const contextMenu = {};
 
 /**
+ * Note, the 'Add' menu in the upper right corner is effectively
+ * a 'More...' menu (at least on small screens). More importantly,
+ * it is not a context menu (even though it uses the same code).
+ *
  * @param {jQuery.Event} e
  */
 contextMenu.add = function (e) {
@@ -89,7 +93,13 @@ contextMenu.add = function (e) {
 		}
 	}
 
-	basicContext.show(items, e.originalEvent);
+	basicContext.show(items, e.originalEvent, null, () => {
+		// use callback of basicContext to add an id and use CSS
+		// formatting to override hardcoded positioning of the
+		// menu based on mouse/tap location and more.
+		let menu = document.querySelector(".basicContext");
+		menu.setAttribute("id", "addMenu");
+	});
 
 	upload.notify();
 };

--- a/styles/main/_basicContext.custom.scss
+++ b/styles/main/_basicContext.custom.scss
@@ -7,6 +7,7 @@
 	border: 1px solid black(0.7);
 	border-bottom: 1px solid black(0.8);
 	transition: none;
+	max-width: 240px;
 
 	&__item {
 		margin-bottom: 2px;
@@ -32,6 +33,8 @@
 	&__data {
 		min-width: auto;
 		padding: 6px 25px 7px 12px;
+		white-space: normal;
+		overflow-wrap: normal;
 
 		@media (hover: none) and (pointer: coarse) {
 			// increase size of menu entries for touch devices

--- a/styles/main/_basicContext.extended.scss
+++ b/styles/main/_basicContext.extended.scss
@@ -1,5 +1,17 @@
 // Extended Theme -------------------------------------------------------------- //
+#addMenu {
+	// positioning of add menu in upper right corner
+	top: 48px !important;
+	left: unset !important;
+	right: 4px;
+}
+
 .basicContext {
+	&__data {
+		// make room for icon
+		padding-left: 40px;
+	}
+
 	&__data .cover {
 		position: absolute;
 		background-color: #222;
@@ -14,7 +26,8 @@
 
 	&__data .iconic {
 		display: inline-block;
-		margin: 0 10px 0 1px;
+		// shift icon into the margin
+		margin: 0 10px 0 -22px;
 		width: 11px;
 		height: 10px;
 		fill: white(1);


### PR DESCRIPTION
This PR fixes #309 by limiting the width of context menus and wrapping long menu entries. As a small aside it also assigns a fixed position to the add/more menu (upper right corner) rather than based on the click location (always below the menu bar rather than overlapping).