### PR TITLE
Add ResizeObserver polyfill to frontend.js (#382)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,7 @@ paths.frontend = {
 		"node_modules/stackblur-canvas/dist/stackblur.min.js",
 		"node_modules/@lychee-org/leaflet.photo/Leaflet.Photo.js",
 		"node_modules/@lychee-org/basiccontext/dist/basicContext.min.js",
+		"node_modules/resize-observer-polyfill/dist/ResizeObserver.js",
 		"../dist/_frontend--javascript.js",
 	],
 	scss: ["./styles/main/*.scss"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"mousetrap": "^1.6.0",
 				"multiselect-two-sides": "^2.5.5",
 				"qr-creator": "^1.0.0",
+				"resize-observer-polyfill": "^1.5.1",
 				"sprintf-js": "^1.1.2",
 				"stackblur-canvas": "^2.5.0"
 			},
@@ -9514,6 +9515,11 @@
 			"integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
 			"dev": true
 		},
+		"node_modules/resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+		},
 		"node_modules/resolve": {
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -18036,6 +18042,11 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
 			"dev": true
+		},
+		"resize-observer-polyfill": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
 			"version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"mousetrap": "^1.6.0",
 		"multiselect-two-sides": "^2.5.5",
 		"qr-creator": "^1.0.0",
+		"resize-observer-polyfill": "^1.5.1",
 		"sprintf-js": "^1.1.2",
 		"stackblur-canvas": "^2.5.0"
 	},


### PR DESCRIPTION
This adds the resize-observer-polyfill module to frontend.js, which allows the frontend to run on browsers that do not support ResizeObserver (like iOS 12).