### PR TITLE
Hide share button on photos page when share_button_visible is false (#384)

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -534,7 +534,7 @@ header.setMode = function (mode) {
 				const e = $("#button_visibility", "#lychee_toolbar_photo");
 				e.show();
 			}
-			if (!lychee.enable_button_share) {
+			if (!lychee.enable_button_share || !lychee.share_button_visible) {
 				const e = $("#button_share", "#lychee_toolbar_photo");
 				e.hide();
 			} else {


### PR DESCRIPTION
Fixes #384

The "#button_share" element is being hidden before (`if (!lychee.share_button_visible)` block), however it is shown again in the "Hide buttons if needed" block. It should only be shown if `enable_button_share` and `share_button_visible` are truthy.