### PR TITLE
Fix more menu in photo view (#387)

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -502,9 +502,7 @@ header.setMode = function (mode) {
 					(
 						album.isUploadable() ||
 						(photo.json &&
-							!photo.json.rights.can_download &&
-							!photo.json.rights.can_access_full_photo &&
-							!(photo.json.size_variants.original.url && photo.json.size_variants.original.url !== ""))
+							(photo.json.rights.can_download || photo.json.rights.can_access_full_photo || photo.json.size_variants.original.url))
 					)
 				)
 			) {


### PR DESCRIPTION
Fixes #387 

This logic nesting is not very intuitive. I tried to untangle it and fix the "hide more menu" functionality.
It now works for my examples (public album with and without download enabled, hidden album with download enabled).