### PR TITLE
Fix more menu in photo view (#387)

### DIFF
--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -502,7 +502,7 @@ header.setMode = function (mode) {
 					(
 						album.isUploadable() ||
 						(photo.json &&
-							(photo.json.rights.can_download || photo.json.rights.can_access_full_photo && photo.json.size_variants.original.url))
+							(photo.json.rights.can_download || (photo.json.rights.can_access_full_photo && photo.json.size_variants.original.url)))
 					)
 				)
 			) {

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -502,9 +502,7 @@ header.setMode = function (mode) {
 					(
 						album.isUploadable() ||
 						(photo.json &&
-							!photo.json.rights.can_download &&
-							!photo.json.rights.can_access_full_photo &&
-							!(photo.json.size_variants.original.url && photo.json.size_variants.original.url !== ""))
+							(photo.json.rights.can_download || photo.json.rights.can_access_full_photo || photo.json.size_variants.original.url))
 					)
 				)
 			) {

--- a/scripts/main/header.js
+++ b/scripts/main/header.js
@@ -502,7 +502,7 @@ header.setMode = function (mode) {
 					(
 						album.isUploadable() ||
 						(photo.json &&
-							(photo.json.rights.can_download || photo.json.rights.can_access_full_photo || photo.json.size_variants.original.url))
+							(photo.json.rights.can_download || photo.json.rights.can_access_full_photo && photo.json.size_variants.original.url))
 					)
 				)
 			) {


### PR DESCRIPTION
Fixes #387

This is the successor to #388: when there is a full-size URL available, but the viewer is not allowed to download it, the menu should also be hidden.