### PR TITLE
Use sessionStorage instead of localStorage for scroll position (#346)

### DIFF
--- a/scripts/main/init.js
+++ b/scripts/main/init.js
@@ -412,7 +412,7 @@ $(document).ready(function () {
 	 */
 	const rememberScrollPage = function () {
 		if ((visible.albums() && !visible.search()) || visible.album()) {
-			let urls = JSON.parse(localStorage.getItem("scroll"));
+			let urls = JSON.parse(sessionStorage.getItem("scroll"));
 			if (urls == null || urls.length < 1) {
 				urls = {};
 			}
@@ -426,7 +426,7 @@ $(document).ready(function () {
 				delete urls[urlWindow];
 			}
 
-			localStorage.setItem("scroll", JSON.stringify(urls));
+			sessionStorage.setItem("scroll", JSON.stringify(urls));
 		}
 	};
 

--- a/scripts/main/view.js
+++ b/scripts/main/view.js
@@ -295,7 +295,7 @@ view.album = {
 		/** @returns {void} */
 		restoreScroll: function () {
 			// Restore scroll position
-			const urls = JSON.parse(localStorage.getItem("scroll"));
+			const urls = JSON.parse(sessionStorage.getItem("scroll"));
 			const urlWindow = window.location.href;
 			$("#lychee_view_container").scrollTop(urls != null && urls[urlWindow] ? urls[urlWindow] : 0);
 		},


### PR DESCRIPTION
With this PR, Lychee saves the scroll position to sessionStorage instead of localStorage, so scroll positions are not kept between tabs/sessions.

The current behaviour can be confusing, especially when opening Lychee after a while, navigating to an album and finding the scroll position at some random value. Using sessionStorage clears the positions when the browser window/tab is closed, while still maintaining the positions while navigating in the same window/tab.

Completely removing the rememberScroll logic is not possible yet, since this would lead to a different, yet still confusing behaviour when navigating between albums and photos, and when using the back/forward buttons of the browser.

So the proper fix for #346 would be to _not_ restore the scroll position when navigating forward by clicking on an item, but restoring the scroll position when either navigating backward or navigating forward using the browser's forward button.