### PR TITLE
Send the file's last modified time to backend

### DIFF
--- a/scripts/main/upload.js
+++ b/scripts/main/upload.js
@@ -422,6 +422,7 @@ upload.start = {
 			// string `""`. Form data falsely converts the value `null` to the
 			// literal string `"null"`.
 			formData.append("albumID", albumID ? albumID : "");
+			formData.append("fileLastModifiedTime", files[fileIdx].lastModified);
 			formData.append("file", files[fileIdx]);
 
 			// We must not use the `onload` event of the `XMLHttpRequestUpload`


### PR DESCRIPTION
This PR is part of the https://github.com/LycheeOrg/Lychee/issues/1729 enhancement.

It modifies the front-end to also send the file's modified time to the back-end. The time is sent as a timestamp.