### PR TITLE
Fixes #1775 from LycheeOrg

### DIFF
--- a/scripts/main/lychee.js
+++ b/scripts/main/lychee.js
@@ -897,7 +897,7 @@ lychee.load = function (autoplay = true) {
 	} else {
 		albumID = hashMatch[0];
 		if (albumID === SearchAlbumIDPrefix && hashMatch.length > 1) {
-			albumID += "/" + hashMatch[1];
+			albumID += "/" + decodeURIComponent(hashMatch[1]);
 		}
 		photoID = hashMatch[album.isSearchID(albumID) ? 2 : 1];
 	}


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee/issues/1775

albumID is not urldecoded which results to a fail when checking against album.json.id === albumID. This is fixed here by urldecoding.